### PR TITLE
Also add UNIXODBC_INCLUDE_DIR for non-Darwin platforms

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -85,6 +85,10 @@ if sys.platform == 'darwin':
     base_library_link_args.append('-dynamiclib')
 else:
     python_module_link_args.append("-Wl,-rpath,$ORIGIN")
+    if 'UNIXODBC_INCLUDE_DIR' in os.environ:
+        include_dirs.append(os.getenv('UNIXODBC_INCLUDE_DIR'))
+    if 'UNIXODBC_LIBRARY_DIR' in os.environ:
+        library_dirs.append(os.getenv('UNIXODBC_LIBRARY_DIR'))
 
 
 def get_extension_modules():


### PR DESCRIPTION
This is required for Linux conda packages. Once merged, I would also need a release.