### PR TITLE
Replace boost gregorian date

### DIFF
--- a/cpp/turbodbc/Library/src/field_translators/date_translator.cpp
+++ b/cpp/turbodbc/Library/src/field_translators/date_translator.cpp
@@ -14,7 +14,10 @@ date_translator::~date_translator() = default;
 field date_translator::do_make_field(char const * data_pointer) const
 {
 	auto const date = reinterpret_cast<SQL_DATE_STRUCT const *>(data_pointer);
-	std::tm tm_date = {0, 0, 0, date->day, date->month - 1, date->year - 1900}
+	std::tm tm_date = {};
+	tm_date.tm_year = date->year - 1900;
+	tm_date.tm_mon  = date->month - 1;
+	tm_date.tm_mday = date->day;
 	return tm_date;
 }
 

--- a/cpp/turbodbc/Library/src/field_translators/date_translator.cpp
+++ b/cpp/turbodbc/Library/src/field_translators/date_translator.cpp
@@ -14,7 +14,8 @@ date_translator::~date_translator() = default;
 field date_translator::do_make_field(char const * data_pointer) const
 {
 	auto const date = reinterpret_cast<SQL_DATE_STRUCT const *>(data_pointer);
-	return {boost::gregorian::date(date->year, date->month, date->day)};
+	std::tm tm_date = {0, 0, 0, date->day, date->month - 1, date->year - 1900}
+	return tm_date;
 }
 
 

--- a/cpp/turbodbc/Library/src/make_description.cpp
+++ b/cpp/turbodbc/Library/src/make_description.cpp
@@ -62,7 +62,7 @@ namespace {
 			return new boolean_description;
 		}
 
-		description_ptr operator()(boost::gregorian::date const &) const
+		description_ptr operator()(std::tm const &) const
 		{
 			return new date_description;
 		}

--- a/cpp/turbodbc/Library/src/parameter_sets/set_field.cpp
+++ b/cpp/turbodbc/Library/src/parameter_sets/set_field.cpp
@@ -32,7 +32,7 @@ namespace {
 			return parameter_.is_suitable_for(type_code::timestamp, size_not_important);
 		}
 
-		bool operator()(boost::gregorian::date const &) const {
+		bool operator()(std::tm const &) const {
 			return parameter_.is_suitable_for(type_code::date, size_not_important);
 		}
 
@@ -87,13 +87,13 @@ namespace {
 			destination_.indicator = sizeof(SQL_TIMESTAMP_STRUCT);
 		}
 
-		void operator()(boost::gregorian::date const & value)
+		void operator()(std::tm const & value)
 		{
 			auto destination = reinterpret_cast<SQL_DATE_STRUCT *>(destination_.data_pointer);
 
-			destination->year = value.year();
-			destination->month = value.month();
-			destination->day = value.day();
+			destination->year  = value.tm_year;
+			destination->month = value.tm_mon;
+			destination->day   = value.tm_mday;
 
 			destination_.indicator = sizeof(SQL_DATE_STRUCT);
 		}

--- a/cpp/turbodbc/Library/turbodbc/field.h
+++ b/cpp/turbodbc/Library/turbodbc/field.h
@@ -2,7 +2,6 @@
 
 #include <boost/variant/variant.hpp>
 #include <boost/optional.hpp>
-#include <boost/date_time/gregorian/gregorian.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <string>
 
@@ -16,7 +15,7 @@ using field = boost::variant<	long,
 								std::string,
 								bool,
 								double,
-								boost::gregorian::date,
+								std::tm,
 								boost::posix_time::ptime>;
 
 /**

--- a/cpp/turbodbc/Test/tests/description_test.cpp
+++ b/cpp/turbodbc/Test/tests/description_test.cpp
@@ -1,4 +1,5 @@
 #include "turbodbc/description.h"
+#include "mock_classes.h"
 
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>

--- a/cpp/turbodbc/Test/tests/description_test.cpp
+++ b/cpp/turbodbc/Test/tests/description_test.cpp
@@ -1,8 +1,8 @@
 #include "turbodbc/description.h"
-#include "mock_classes.h"
 
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
+#include <tests/mock_classes.h>
 
 
 namespace {

--- a/cpp/turbodbc/Test/tests/field_translator_test.cpp
+++ b/cpp/turbodbc/Test/tests/field_translator_test.cpp
@@ -2,6 +2,7 @@
 
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
+#include <tests/mock_classes.h>
 
 #include <sql.h>
 

--- a/cpp/turbodbc/Test/tests/field_translators/boolean_translator_test.cpp
+++ b/cpp/turbodbc/Test/tests/field_translators/boolean_translator_test.cpp
@@ -1,6 +1,7 @@
 #include "turbodbc/field_translators/boolean_translator.h"
 
 #include <gtest/gtest.h>
+#include <tests/mock_classes.h>
 
 
 using turbodbc::field_translators::boolean_translator;

--- a/cpp/turbodbc/Test/tests/field_translators/date_translator_test.cpp
+++ b/cpp/turbodbc/Test/tests/field_translators/date_translator_test.cpp
@@ -19,6 +19,6 @@ TEST(DateTranslatorTest, MakeField)
 	std::tm expected = std::tm {};
 	expected.tm_year = 2015 - 1900;
 	expected.tm_mon  = 12 - 1;
-	expected.tm_mday = 7;
+	expected.tm_mday = 31;
 	EXPECT_EQ(turbodbc::field(expected), *(translator.make_field(as_const[0])));
 }

--- a/cpp/turbodbc/Test/tests/field_translators/date_translator_test.cpp
+++ b/cpp/turbodbc/Test/tests/field_translators/date_translator_test.cpp
@@ -1,6 +1,7 @@
 #include "turbodbc/field_translators/date_translator.h"
 
 #include <gtest/gtest.h>
+#include <tests/mock_classes.h>
 
 
 using turbodbc::field_translators::date_translator;
@@ -15,6 +16,9 @@ TEST(DateTranslatorTest, MakeField)
 	date_translator const translator;
 
 	*reinterpret_cast<SQL_DATE_STRUCT *>(element.data_pointer) = {2015, 12, 31};
-	boost::gregorian::date const expected{2015, 12, 31};
+	std::tm expected = std::tm {};
+	expected.tm_year = 2015 - 1900;
+	expected.tm_mon  = 12 - 1;
+	expected.tm_mday = 7;
 	EXPECT_EQ(turbodbc::field(expected), *(translator.make_field(as_const[0])));
 }

--- a/cpp/turbodbc/Test/tests/field_translators/float64_translator_test.cpp
+++ b/cpp/turbodbc/Test/tests/field_translators/float64_translator_test.cpp
@@ -1,6 +1,7 @@
 #include "turbodbc/field_translators/float64_translator.h"
 
 #include <gtest/gtest.h>
+#include <tests/mock_classes.h>
 
 
 using turbodbc::field_translators::float64_translator;

--- a/cpp/turbodbc/Test/tests/field_translators/int64_translator_test.cpp
+++ b/cpp/turbodbc/Test/tests/field_translators/int64_translator_test.cpp
@@ -1,6 +1,7 @@
 #include "turbodbc/field_translators/int64_translator.h"
 
 #include <gtest/gtest.h>
+#include <tests/mock_classes.h>
 
 
 using turbodbc::field_translators::int64_translator;

--- a/cpp/turbodbc/Test/tests/field_translators/string_translator_test.cpp
+++ b/cpp/turbodbc/Test/tests/field_translators/string_translator_test.cpp
@@ -1,6 +1,7 @@
 #include "turbodbc/field_translators/string_translator.h"
 
 #include <gtest/gtest.h>
+#include <tests/mock_classes.h>
 
 
 using turbodbc::field_translators::string_translator;

--- a/cpp/turbodbc/Test/tests/field_translators/timestamp_translator_test.cpp
+++ b/cpp/turbodbc/Test/tests/field_translators/timestamp_translator_test.cpp
@@ -1,6 +1,7 @@
 #include "turbodbc/field_translators/timestamp_translator.h"
 
 #include <gtest/gtest.h>
+#include <tests/mock_classes.h>
 
 
 using turbodbc::field_translators::timestamp_translator;

--- a/cpp/turbodbc/Test/tests/make_description_of_value_test.cpp
+++ b/cpp/turbodbc/Test/tests/make_description_of_value_test.cpp
@@ -2,6 +2,7 @@
 
 #include <gtest/gtest.h>
 #include <turbodbc/descriptions.h>
+#include <tests/mock_classes.h>
 
 #include <sqlext.h>
 #include <sstream>
@@ -35,7 +36,11 @@ TEST(MakeDescriptionOfValueTest, FromBool)
 
 TEST(MakeDescriptionOfValueTest, FromDate)
 {
-	field const value(boost::gregorian::date(2016, 1, 7));
+	std::tm testval = std::tm {};
+	testval.tm_year = 2016 - 1900;
+	testval.tm_mon  = 1 - 1;
+	testval.tm_mday = 7;
+	field const value(testval);
 	auto description = make_description(value);
 	ASSERT_TRUE( dynamic_cast<turbodbc::date_description const *>(description.get()) );
 }

--- a/cpp/turbodbc/Test/tests/mock_classes.cpp
+++ b/cpp/turbodbc/Test/tests/mock_classes.cpp
@@ -9,3 +9,14 @@ default_mock_statement::default_mock_statement() = default;
 default_mock_statement::~default_mock_statement() = default;
 
 }
+
+std::ostream& operator<<(std::ostream& os, const std::tm& mytm)
+{
+	os << std::asctime(&mytm);
+	return os;
+}
+
+bool operator==(const std::tm LHS, const std::tm RHS)
+{
+	return LHS.tm_year == RHS.tm_year && LHS.tm_mon == RHS.tm_mon && LHS.tm_mday == RHS.tm_mday;
+}

--- a/cpp/turbodbc/Test/tests/mock_classes.cpp
+++ b/cpp/turbodbc/Test/tests/mock_classes.cpp
@@ -18,5 +18,6 @@ std::ostream& operator<<(std::ostream& os, const std::tm& mytm)
 
 bool operator==(const std::tm LHS, const std::tm RHS)
 {
-	return LHS.tm_year == RHS.tm_year && LHS.tm_mon == RHS.tm_mon && LHS.tm_mday == RHS.tm_mday;
+	return LHS.tm_year == RHS.tm_year && LHS.tm_mon == RHS.tm_mon && LHS.tm_mday == RHS.tm_mday &&
+		LHS.tm_hour == RHS.tm_hour && LHS.tm_min == RHS.tm_min && LHS.tm_sec == RHS.tm_sec;
 }

--- a/cpp/turbodbc/Test/tests/mock_classes.h
+++ b/cpp/turbodbc/Test/tests/mock_classes.h
@@ -54,11 +54,14 @@ namespace turbodbc_test {
 		MOCK_CONST_METHOD0( do_more_results, bool());
 	};
 
-    using mock_connection = testing::NiceMock<default_mock_connection>;
-    using mock_statement = testing::NiceMock<default_mock_statement>;
+	using mock_connection = testing::NiceMock<default_mock_connection>;
+	using mock_statement = testing::NiceMock<default_mock_statement>;
 
 
 }
 
+std::ostream& operator<<(std::ostream& os, const std::tm& mytm);
+
+bool operator==(const std::tm LHS, const std::tm RHS);
 
 

--- a/cpp/turbodbc/Test/tests/parameter_sets/set_field_test.cpp
+++ b/cpp/turbodbc/Test/tests/parameter_sets/set_field_test.cpp
@@ -78,7 +78,12 @@ TEST(SetFieldTest, ParameterIsSuitableForDate)
 	parameter const boolean_parameter(statement, param_index, n_params,
 	                                  std::unique_ptr<description>(new boolean_description()));
 
-	field const value(boost::gregorian::date{2016, 9, 23});
+
+	std::tm testval = std::tm {};
+	testval.tm_year = 2016 - 1900;
+	testval.tm_mon  = 9 - 1;
+	testval.tm_mday = 23;
+	field const value(testval);
 	EXPECT_TRUE(parameter_is_suitable_for(date_parameter, value));
 	EXPECT_FALSE(parameter_is_suitable_for(boolean_parameter, value));
 }
@@ -161,7 +166,10 @@ TEST(SetFieldTest, SetFieldTimestamp)
 
 TEST(SetFieldTest, SetFieldDate)
 {
-	boost::gregorian::date const date{2015, 12, 31};
+	std::tm date = std::tm {};
+	date.tm_year = 2015 - 1900;
+	date.tm_mon  = 12 - 1;
+	date.tm_mday = 31;
 
 	cpp_odbc::multi_value_buffer buffer(sizeof(SQL_DATE_STRUCT), 1);
 	auto element = buffer[0];

--- a/cpp/turbodbc/Test/tests/parameter_sets/set_field_test.cpp
+++ b/cpp/turbodbc/Test/tests/parameter_sets/set_field_test.cpp
@@ -167,8 +167,8 @@ TEST(SetFieldTest, SetFieldTimestamp)
 TEST(SetFieldTest, SetFieldDate)
 {
 	std::tm date = std::tm {};
-	date.tm_year = 2015 - 1900;
-	date.tm_mon  = 12 - 1;
+	date.tm_year = 2015;
+	date.tm_mon  = 12;
 	date.tm_mday = 31;
 
 	cpp_odbc::multi_value_buffer buffer(sizeof(SQL_DATE_STRUCT), 1);

--- a/cpp/turbodbc/Test/tests/parameter_sets/set_field_test.cpp
+++ b/cpp/turbodbc/Test/tests/parameter_sets/set_field_test.cpp
@@ -182,6 +182,41 @@ TEST(SetFieldTest, SetFieldDate)
 	EXPECT_EQ(sizeof(SQL_DATE_STRUCT), element.indicator);
 }
 
+TEST(SetFieldTest, SetFieldDatePre1400)
+{
+	std::tm date = std::tm {};
+	date.tm_year = 1000;
+	date.tm_mon  = 4;
+	date.tm_mday = 1;
+
+	cpp_odbc::multi_value_buffer buffer(sizeof(SQL_DATE_STRUCT), 1);
+	auto element = buffer[0];
+
+	set_field(turbodbc::field{date}, element);
+	auto const as_sql_date = reinterpret_cast<SQL_DATE_STRUCT const *>(element.data_pointer);
+	EXPECT_EQ(1000, as_sql_date->year);
+	EXPECT_EQ(4, as_sql_date->month);
+	EXPECT_EQ(1, as_sql_date->day);
+	EXPECT_EQ(sizeof(SQL_DATE_STRUCT), element.indicator);
+}
+
+TEST(SetFieldTest, SetFieldDatePost10000)
+{
+	std::tm date = std::tm {};
+	date.tm_year = 11567;
+	date.tm_mon  = 7;
+	date.tm_mday = 22;
+
+	cpp_odbc::multi_value_buffer buffer(sizeof(SQL_DATE_STRUCT), 1);
+	auto element = buffer[0];
+
+	set_field(turbodbc::field{date}, element);
+	auto const as_sql_date = reinterpret_cast<SQL_DATE_STRUCT const *>(element.data_pointer);
+	EXPECT_EQ(11567, as_sql_date->year);
+	EXPECT_EQ(7, as_sql_date->month);
+	EXPECT_EQ(22, as_sql_date->day);
+	EXPECT_EQ(sizeof(SQL_DATE_STRUCT), element.indicator);
+}
 
 TEST(SetFieldTest, SetFieldString)
 {

--- a/cpp/turbodbc_numpy/Library/src/datetime_column.cpp
+++ b/cpp/turbodbc_numpy/Library/src/datetime_column.cpp
@@ -33,13 +33,18 @@ namespace {
 		return (ts - timestamp_epoch).total_microseconds();
 	}
 
-	std::tm epoch = {0, 0, 0, 1, 0, 70, 0, 0, 0, 0, 0};
-
 	long date_to_days(char const * data_pointer)
 	{
 		auto & sql_date = *reinterpret_cast<SQL_DATE_STRUCT const *>(data_pointer);
-		std::tm date = {0, 0, 0, sql_date.day, sql_date.month - 1, sql_date.year - 1900, 0, 0, 0, 0, 0};
-		return (difftime(mktime(&date), mktime(&epoch)))/(60*60*24);
+		std::tm tm_epoch = {};
+		tm_epoch.tm_year = 70;
+		tm_epoch.tm_mon  = 0;
+		tm_epoch.tm_mday = 1;
+		std::tm date     = {};
+		date.tm_year     = sql_date.year - 1900;
+		date.tm_mon      = sql_date.month - 1;
+		date.tm_mday     = sql_date.day;
+		return (difftime(mktime(&date), mktime(&tm_epoch)))/(60*60*24);
 	}
 
 	datetime_column::converter make_converter(turbodbc::type_code type)

--- a/cpp/turbodbc_numpy/Library/src/datetime_column.cpp
+++ b/cpp/turbodbc_numpy/Library/src/datetime_column.cpp
@@ -4,7 +4,6 @@
 
 #include <Python.h>
 
-#include <boost/date_time/gregorian/gregorian_types.hpp>
 #include <boost/date_time/posix_time/posix_time_types.hpp>
 
 #include <sql.h>
@@ -34,13 +33,13 @@ namespace {
 		return (ts - timestamp_epoch).total_microseconds();
 	}
 
-	boost::gregorian::date const date_epoch(1970, 1, 1);
+	std::tm epoch = {0, 0, 0, 1, 0, 70, 0, 0, 0, 0, 0};
 
 	long date_to_days(char const * data_pointer)
 	{
 		auto & sql_date = *reinterpret_cast<SQL_DATE_STRUCT const *>(data_pointer);
-		boost::gregorian::date const date(sql_date.year, sql_date.month, sql_date.day);
-		return (date - date_epoch).days();
+		std::tm date = {0, 0, 0, sql_date.day, sql_date.month - 1, sql_date.year - 1900, 0, 0, 0, 0, 0};
+		return (difftime(mktime(&date), mktime(&epoch)))/(60*60*24);
 	}
 
 	datetime_column::converter make_converter(turbodbc::type_code type)


### PR DESCRIPTION
I don't believe you would be happy with the refactoring to the tests, but please help me out to get this right.

Unit tests also failed with missing py.test error that I wasn't able to figure out how to resolve in my setup. 