### PR TITLE
Numpy batched fetch api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ Version 1.1.0 (unreleased)
     In particular, a few `long` types were converted to `intptr_t` and `int64_t`
     where appropriate. In particular, this affects the `field` type that may be used
     by C++ end users (so they exist).
-*   Added new cursor.fetchnumpybatches method which returns a generator to
+*   Added new `cursor.fetchnumpybatches()` method which returns a generator to
     iterate over result sets in batch sizes as defined by buffer size or rowcount
 
 Version 1.0.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ Version 1.1.0 (unreleased)
     In particular, a few `long` types were converted to `intptr_t` and `int64_t`
     where appropriate. In particular, this affects the `field` type that may be used
     by C++ end users (so they exist).
+*   Added new cursor.fetchnumpybatches method which returns a generator to
+    iterate over result sets in batch sizes as defined by buffer size or rowcount
 
 Version 1.0.5
 =============
@@ -100,7 +102,7 @@ Version 0.4.1
     (linking is already done by the Python interpreter). This was always
     the case for the libraries in the packages uploaded to PyPI, so no
     change was necessary here.
-*   Internal: Some modifications to the structure of the underlying 
+*   Internal: Some modifications to the structure of the underlying
     C++ code.
 
 Version 0.4.0
@@ -122,7 +124,7 @@ Version 0.3.0
     batch in the background. This may yield substantial performance improvements
     in the right circumstances (results are retrieved in roughly the same speed
     as they are converted to Python objects).
-    
+
     Ansynchronous I/O support is experimental. Enable it with
     `turbodbc.connect('My data source name', use_async_io=True)`
 
@@ -149,7 +151,7 @@ Version 0.2.3
 
 *   Fix issue that only lists were allowed for specifying parameters for queries
 *   Improve parameter memory consumption when the database reports very large
-    string parameter sizes 
+    string parameter sizes
 *   C++ backend: Provides more low-level ways to access the result set
 
 Version 0.2.2

--- a/README.md
+++ b/README.md
@@ -149,10 +149,23 @@ Here is how to execute an `INSERT` query with many parameters:
 NumPy support
 -------------
 
-Here is how to retrieve a result set in the form of NumPy arrays:
+Here is how to retrieve a full result set in the form of NumPy arrays:
 
     >>> cursor.execute("SELECT A, B FROM my_table")
     >>> cursor.fetchallnumpy()
+    OrderedDict([('A', masked_array(data = [42 --],
+                                    mask = [False True],
+                                    fill_value = 999999)),
+                 ('B', masked_array(data = [3.14 2.71],
+                                    mask = [False False],
+                                    fill_value = 1e+20))])
+
+You can also fetch numpy result sets in batches, based on the `read_buffer_size` attribute on the connection, using an iterable:
+
+    >>> cursor.execute("SELECT A, B FROM my_table")
+    >>> batches = cursor.fetchnumpybatches()
+    >>> for batch in batches:
+    ...     print(batch)
     OrderedDict([('A', masked_array(data = [42 --],
                                     mask = [False True],
                                     fill_value = 999999)),

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Here is how to retrieve a full result set in the form of NumPy arrays:
                                     mask = [False False],
                                     fill_value = 1e+20))])
 
-You can also fetch numpy result sets in batches, based on the `read_buffer_size` attribute on the connection, using an iterable:
+You can also fetch NumPy result sets in batches, based on the `read_buffer_size` attribute on the connection, using an iterable:
 
     >>> cursor.execute("SELECT A, B FROM my_table")
     >>> batches = cursor.fetchnumpybatches()

--- a/cpp/turbodbc_numpy/Library/src/numpy_result_set.cpp
+++ b/cpp/turbodbc_numpy/Library/src/numpy_result_set.cpp
@@ -51,12 +51,6 @@ numpy_result_set::numpy_result_set(turbodbc::result_sets::result_set & base) :
 pybind11::object numpy_result_set::fetch_next_batch()
 {
 	std::size_t rows_in_batch = base_result_.fetch_next_batch();
-
-	if (!rows_in_batch)
-	{
-		throw pybind11::stop_iteration();
-	}
-
 	auto const column_info = base_result_.get_column_info();
 	auto const n_columns = column_info.size();
 

--- a/cpp/turbodbc_numpy/Library/src/numpy_result_set.cpp
+++ b/cpp/turbodbc_numpy/Library/src/numpy_result_set.cpp
@@ -48,10 +48,15 @@ numpy_result_set::numpy_result_set(turbodbc::result_sets::result_set & base) :
 {
 }
 
-
-pybind11::object numpy_result_set::fetch_all()
+pybind11::object numpy_result_set::fetch_next_batch()
 {
 	std::size_t rows_in_batch = base_result_.fetch_next_batch();
+
+	if (!rows_in_batch)
+	{
+		throw pybind11::stop_iteration();
+	}
+
 	auto const column_info = base_result_.get_column_info();
 	auto const n_columns = column_info.size();
 
@@ -60,14 +65,11 @@ pybind11::object numpy_result_set::fetch_all()
 		columns.push_back(make_masked_column(column_info[i].type));
 	}
 
-	do {
-		auto const buffers = base_result_.get_buffers();
+	auto const buffers = base_result_.get_buffers();
 
-		for (std::size_t i = 0; i != n_columns; ++i) {
-			columns[i]->append(buffers[i].get(), rows_in_batch);
-		}
-		rows_in_batch = base_result_.fetch_next_batch();
-	} while (rows_in_batch != 0);
+	for (std::size_t i = 0; i != n_columns; ++i) {
+		columns[i]->append(buffers[i].get(), rows_in_batch);
+	}
 
 	return as_python_list(columns);
 }

--- a/cpp/turbodbc_numpy/Library/src/python_bindings.cpp
+++ b/cpp/turbodbc_numpy/Library/src/python_bindings.cpp
@@ -40,7 +40,7 @@ PYBIND11_PLUGIN(turbodbc_numpy_support) {
     pybind11::module module("turbodbc_numpy_support", "Native helpers for turbodbc's NumPy support");
 
     pybind11::class_<numpy_result_set>(module, "NumpyResultSet")
-        .def("fetch_all", &numpy_result_set::fetch_all);
+        .def("fetch_next_batch", &numpy_result_set::fetch_next_batch);
 
     module.def("make_numpy_result_set", make_numpy_result_set);
     return module.ptr();

--- a/cpp/turbodbc_numpy/Library/turbodbc_numpy/numpy_result_set.h
+++ b/cpp/turbodbc_numpy/Library/turbodbc_numpy/numpy_result_set.h
@@ -21,9 +21,9 @@ public:
 
 	/**
 	 * @brief Retrieve a Python object which contains
-	 *        values and masks for all data
+	 *        values and masks for a fixed batch size
 	 */
-	pybind11::object fetch_all();
+	pybind11::object fetch_next_batch();
 
 private:
 	turbodbc::result_sets::result_set & base_result_;

--- a/python/turbodbc/cursor.py
+++ b/python/turbodbc/cursor.py
@@ -7,23 +7,24 @@ from turbodbc_intern import make_row_based_result_set, make_parameter_set
 
 from .exceptions import translate_exceptions, InterfaceError, Error
 
-
 def _has_numpy_support():
+
     try:
         import turbodbc_numpy_support
         return True
     except ImportError:
-        return False
+         return False
 
-
-def _make_masked_array(data, mask):
+def _make_masked_arrays(result_batch):
     from numpy.ma import MaskedArray
     from numpy import object_
-    if isinstance(data, list):
-        return MaskedArray(data=data, mask=mask, dtype=object_)
-    else:
-        return MaskedArray(data=data, mask=mask)
-
+    numpy_masked_array = []
+    for data, mask in result_batch:
+        if isinstance(data, list):
+            numpy_masked_array.append(MaskedArray(data=data, mask=mask, dtype=object_))
+        else:
+            numpy_masked_array.append(MaskedArray(data=data, mask=mask))
+    return numpy_masked_array
 
 class Cursor(object):
     def __init__(self, impl):
@@ -104,15 +105,15 @@ class Cursor(object):
         self._assert_valid_result_set()
         result = self.result_set.fetch_row()
         if len(result) == 0:
-            return None 
+            return None
         else:
-            return result  
+            return result
 
-    @translate_exceptions    
+    @translate_exceptions
     def fetchall(self):
         return [row for row in self]
 
-    @translate_exceptions    
+    @translate_exceptions
     def fetchmany(self, size=None):
         if size is None:
             size = self.arraysize
@@ -122,14 +123,34 @@ class Cursor(object):
         return [row for row in islice(self, size)]
 
     def fetchallnumpy(self):
+        if _has_numpy_support():
+            from numpy.ma import concatenate
+        else:
+            raise Error("turbodbc was compiled without numpy support. Please install "
+                        "numpy and reinstall turbodbc")
+        batches = list(self._numpy_batch_generator())
+        column_names = [description[0] for description in self.description]
+        if len(batches) == 0:
+            return None
+        elif len(batches) == 1:
+            return OrderedDict(zip(column_names, batches[0]))
+        return OrderedDict(zip(column_names, [concatenate(column) for column in zip(*batches)]))
+
+    def fetchbatchnumpy(self):
+        next_batch = next(self._numpy_batch_generator(), None)
+        if next_batch:
+            column_names = [description[0] for description in self.description]
+            return OrderedDict(zip(column_names, next_batch))
+        return next_batch
+
+    def _numpy_batch_generator(self):
         self._assert_valid_result_set()
         if _has_numpy_support():
             from turbodbc_numpy_support import make_numpy_result_set
             numpy_result_set = make_numpy_result_set(self.impl.get_result_set())
-            column_names = [description[0] for description in self.description]
-            columns = zip(column_names,
-                          [_make_masked_array(data, mask) for data, mask in numpy_result_set.fetch_all()])
-            return OrderedDict(columns)
+            while True:
+                result_batch = numpy_result_set.fetch_next_batch()
+                yield _make_masked_arrays(result_batch)
         else:
             raise Error("turbodbc was compiled without numpy support. Please install "
                         "numpy and reinstall turbodbc")

--- a/python/turbodbc_test/test_select_numpy.py
+++ b/python/turbodbc_test/test_select_numpy.py
@@ -60,8 +60,8 @@ def test_numpy_empty_column_batch_fetch(dsn, configuration):
             for idx, batch in enumerate(batches):
                 assert isinstance(batch, OrderedDict)
                 assert len(batch) == 1 # ncols
-                assert isinstance(results[_fix_case(configuration, 'a')], MaskedArray)
-                assert_equal(len(results[_fix_case(configuration, 'a')]), 0)
+                assert isinstance(batch[_fix_case(configuration, 'a')], MaskedArray)
+                assert_equal(len(batch[_fix_case(configuration, 'a')]), 0)
             assert_equal(idx, 0)
 
 @for_each_database

--- a/python/turbodbc_test/test_select_numpy.py
+++ b/python/turbodbc_test/test_select_numpy.py
@@ -129,9 +129,11 @@ def test_numpy_batch_fetch(dsn, configuration):
                                [[1], [2], [3], [4], [5]])
             cursor.execute("SELECT a FROM {} ORDER BY a".format(table_name))
             batches = cursor.fetchnumpybatches()
-            expected_list = [MaskedArray([1, 2], mask=False), MaskedArray([3, 4], mask=False), MaskedArray([5], mask=False)]
+            expected_batches = [MaskedArray([1, 2], mask=False),
+                                MaskedArray([3, 4], mask=False),
+                                MaskedArray([5],    mask=False)]
             for idx, batch in enumerate(batches):
-                expected = expected_list[idx]
+                expected = expected_batches[idx]
                 assert_equal(batch[_fix_case(configuration, 'a')], expected)
             assert_equal(idx, 2)
 

--- a/python/turbodbc_test/test_select_numpy.py
+++ b/python/turbodbc_test/test_select_numpy.py
@@ -48,9 +48,21 @@ def test_numpy_empty_column(dsn, configuration):
             cursor.execute("SELECT a FROM {}".format(table_name))
             results = cursor.fetchallnumpy()
             assert isinstance(results, OrderedDict)
-            assert len(results) == 1
+            assert len(results) == 1 # ncols
             assert isinstance(results[_fix_case(configuration, 'a')], MaskedArray)
 
+@for_each_database
+def test_numpy_empty_column_batch_fetch(dsn, configuration):
+    with open_cursor(configuration) as cursor:
+        with query_fixture(cursor, configuration, 'INSERT INTEGER') as table_name:
+            cursor.execute("SELECT a FROM {}".format(table_name))
+            batches = cursor.fetchnumpybatches()
+            for idx, batch in enumerate(batches):
+                assert isinstance(batch, OrderedDict)
+                assert len(batch) == 1 # ncols
+                assert isinstance(results[_fix_case(configuration, 'a')], MaskedArray)
+                assert_equal(len(results[_fix_case(configuration, 'a')]), 0)
+            assert_equal(idx, 0)
 
 @for_each_database
 def test_numpy_int_column(dsn, configuration):
@@ -109,6 +121,19 @@ def test_numpy_binary_column_larger_than_batch_size(dsn, configuration):
             expected = MaskedArray([1, 2, 3, 4, 5], mask=False)
             assert_equal(results[_fix_case(configuration, 'a')], expected)
 
+@for_each_database
+def test_numpy_batch_fetch(dsn, configuration):
+    with open_cursor(configuration, rows_to_buffer=2) as cursor:
+        with query_fixture(cursor, configuration, 'INSERT INTEGER') as table_name:
+            cursor.executemany("INSERT INTO {} VALUES (?)".format(table_name),
+                               [[1], [2], [3], [4], [5]])
+            cursor.execute("SELECT a FROM {} ORDER BY a".format(table_name))
+            batches = cursor.fetchnumpybatches()
+            expected_list = [MaskedArray([1, 2], mask=False), MaskedArray([3, 4], mask=False), MaskedArray([5], mask=False)]
+            for idx, batch in enumerate(batches):
+                expected = expected_list[idx]
+                assert_equal(batch[_fix_case(configuration, 'a')], expected)
+            assert_equal(idx, 2)
 
 @for_each_database
 def test_numpy_timestamp_column(dsn, configuration):


### PR DESCRIPTION
This is an initial PR to get tests run and feedback against the implementation as it stands for batched numpy fetches, including a python call to do the same.

I rewrote `fetchallnumpy()` -- it looks the same to the user but under the hood is grabbing the generator and concatenating all the chunks together
I implemented `fetchbatchnumpy()` -- This immediately returns the next batch to be fetched
Both these methods are supported under the hood by the generator function `_numpy_batch_generator()` -- this returns a generator object which returns an array of masked arrays for each `next()`, without putting it into an ordered dict (this is left to the user facing methods to do)

I did not write any integration tests yet, as I would like some guidance on what you would like to see.

All feedback appreciated