### PR TITLE
Try to improve CMake build on Windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,7 @@ addons:
       - unixodbc
       - unixodbc-dev
       - libboost-date-time-dev
+      - libboost-locale-dev
       - libboost-system-dev
       - libmyodbc
       - odbc-postgresql=1:09.02.0100-2ubuntu1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,7 +27,7 @@ build_script:
 
     cd turbodbc_build
 
-    cmake ..\turbodbc -DPYBIND11_PYTHON_VERSION=3.6 -A x64
+    cmake ..\turbodbc -DPYBIND11_PYTHON_VERSION=3.6 -DCMAKE_VERBOSE_MAKEFILE=ON -A x64
 
     cmake --build .
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,8 +27,8 @@ build_script:
 
     cd turbodbc_build
 
-    cmake ..\turbodbc -DPYBIND11_PYTHON_VERSION=3.6 -DCMAKE_VERBOSE_MAKEFILE=ON -A x64
+    cmake ..\turbodbc -DPYBIND11_PYTHON_VERSION=3.6 -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_BUILD_TYPE=Release -A x64
 
-    cmake --build .
+    cmake --build . --config Release
 
     dir

--- a/cmake_scripts/default_build_setup.cmake
+++ b/cmake_scripts/default_build_setup.cmake
@@ -25,7 +25,9 @@ if (UNIX)
     set(CMAKE_CXX_FLAGS_DEBUG "-g -O0 -pedantic")
     set(CMAKE_CXX_FLAGS_RELEASE "-O3 -pedantic")
 else()
-    set(CMAKE_CXX_FLAGS "/W4 /EHsc")
+    set(CMAKE_CXX_FLAGS "/W3 /EHsc -DNOMINMAX")
+    set(CMAKE_CXX_FLAGS_DEBUG "/MTd")
+    set(CMAKE_CXX_FLAGS_RELEASE "/MT")
 endif()
 
 if (APPLE)
@@ -43,7 +45,13 @@ include(CTest)
 # to determine its source files.
 add_custom_target(refresh_cmake_configuration
 	ALL # execute on default make
-	touch ${CMAKE_PARENT_LIST_FILE} # make cmake detect configuration is changed on NEXT build
+	cmake -E touch ${CMAKE_PARENT_LIST_FILE} # make cmake detect configuration is changed on NEXT build
 	COMMENT "Forcing refreshing of the CMake configuration. This allows to use globbing safely."
 )
 
+if(WIN32)
+    link_directories("$ENV{PYTHON}/libs")
+    set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS "TRUE")
+    set(Boost_USE_STATIC_RUNTIME "ON")
+    set(Boost_USE_STATIC_LIBS "ON")
+endif()

--- a/cpp/cpp_odbc/Library/CMakeLists.txt
+++ b/cpp/cpp_odbc/Library/CMakeLists.txt
@@ -10,15 +10,6 @@ add_dependencies(cpp_odbc
     refresh_cmake_configuration
 )
 
-if (WIN32)
-    GENERATE_EXPORT_HEADER( cpp_odbc
-        BASE_NAME cpp_odbc
-        EXPORT_MACRO_NAME cpp_odbc_EXPORT
-        EXPORT_FILE_NAME cpp_odbc_Export.h
-        STATIC_DEFINE cpp_odbc_BUILT_AS_STATIC
-        )
-endif()
-
 target_link_libraries(cpp_odbc
     ${Odbc_LIBRARIES}
 )

--- a/cpp/cpp_odbc/Test/CMakeLists.txt
+++ b/cpp/cpp_odbc/Test/CMakeLists.txt
@@ -17,9 +17,14 @@ target_link_libraries(cpp_odbc_test
     gmock_main
     gtest
     gmock
-    pthread
     ${Odbc_LIBRARIES}
 )
+
+IF(UNIX)
+target_link_libraries(cpp_odbc_test
+    pthread
+)
+ENDIF()
 
 add_test(NAME cpp_odbc_unit_test
          COMMAND cpp_odbc_test --gtest_output=xml:${CMAKE_BINARY_DIR}/cpp_odbc_test.xml)

--- a/cpp/turbodbc/CMakeLists.txt
+++ b/cpp/turbodbc/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(Boost REQUIRED COMPONENTS system)
+find_package(Boost REQUIRED COMPONENTS system date_time locale)
 include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
 
 find_package(odbc REQUIRED)

--- a/cpp/turbodbc/Test/CMakeLists.txt
+++ b/cpp/turbodbc/Test/CMakeLists.txt
@@ -21,8 +21,13 @@ target_link_libraries(turbodbc_test
     gmock_main
     gtest
     gmock
+)
+
+IF(UNIX)
+target_link_libraries(turbodbc_test
     pthread
 )
+ENDIF()
 
 add_test(NAME turbodbc_unit_test
          COMMAND turbodbc_test --gtest_output=xml:${CMAKE_BINARY_DIR}/turbodbc_test.xml)

--- a/google_test/CMakeLists.txt
+++ b/google_test/CMakeLists.txt
@@ -1,8 +1,16 @@
+if( WIN32 )
+add_custom_command(
+    OUTPUT googletest_built
+    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/build_google_test.bat
+    COMMAND cmake -E touch googletest_built
+)
+else()
 add_custom_command(
     OUTPUT googletest_built
     COMMAND sh ${CMAKE_CURRENT_SOURCE_DIR}/build_google_test.sh
     COMMAND touch googletest_built
 )
+endif()
 add_custom_target(googletest_build ALL DEPENDS googletest_built)
 
 set(ENV{GOOGLETEST_LIB_DIR} "${CMAKE_CURRENT_BINARY_DIR}/dist/lib")

--- a/google_test/build_google_test.bat
+++ b/google_test/build_google_test.bat
@@ -1,0 +1,7 @@
+echo "Cloning latest google test repository"
+git clone https://github.com/google/googletest.git
+
+md build
+cd build
+cmake ../googletest -DCMAKE_INSTALL_PREFIX=../dist -DCMAKE_VERBOSE_MAKEFILE=ON -A x64
+cmake --build . --target install

--- a/google_test/build_google_test.bat
+++ b/google_test/build_google_test.bat
@@ -3,5 +3,5 @@ git clone https://github.com/google/googletest.git
 
 md build
 cd build
-cmake ../googletest -DCMAKE_INSTALL_PREFIX=../dist -DCMAKE_VERBOSE_MAKEFILE=ON -A x64
-cmake --build . --target install
+cmake ../googletest -DCMAKE_INSTALL_PREFIX=../dist -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_BUILD_TYPE=Release -A x64
+cmake --build . --config Release --target install


### PR DESCRIPTION
Uses CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS instead of GENERATE_EXPORT_HEADER.

touch and sh is usually not available on Windows, so I used cmake -E and bat instead.

Controlling the googletest build is quite awkward, have you considered something like [this](https://crascit.com/2015/07/25/cmake-gtest/)?

