### PR TITLE
add option to use preformatted ODBC connection string

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ To establish a connection, use any of the following commands:
     >>> connection = connect(dsn='My data source name as given by odbc.ini')
     >>> connection = connect(dsn='my dsn', user='my user has precedence')
     >>> connection = connect(dsn='my dsn', username='field names may depend on the driver')
+    >>> connection = connect(connection_string='Driver={PostgreSQL};Server=IP address;Port=5432;Database=myDataBase;Uid=myUsername;Pwd=myPassword;')
 
 To execute a query, you need a `cursor` object:
 

--- a/python/turbodbc/__init__.py
+++ b/python/turbodbc/__init__.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 from .api_constants import apilevel, threadsafety, paramstyle
 from .connect import connect
 from .constructors import Date, Time, Timestamp
-from .exceptions import Error, InterfaceError, DatabaseError
+from .exceptions import Error, InterfaceError, DatabaseError, ParameterError
 from .data_types import STRING, BINARY, NUMBER, DATETIME, ROWID
 from .options import make_options
 from turbodbc_intern import Rows, Megabytes

--- a/python/turbodbc/exceptions.py
+++ b/python/turbodbc/exceptions.py
@@ -24,6 +24,10 @@ class DatabaseError(Error):
     pass 
 
 
+class ParameterError(Error):
+    pass
+
+
 def translate_exceptions(f):
     @wraps(f)
     def wrapper(*args, **kwds):

--- a/python/turbodbc_test/test_connect.py
+++ b/python/turbodbc_test/test_connect.py
@@ -56,3 +56,13 @@ def test_connect_raises_on_ambiguous_parameters():
         connect("foo", connection_string="DRIVER=bar;SERVER=baz;")
     with pytest.raises(ParameterError):
         connect(connection_string="DRIVER=foo;SERVER=bar;", baz="qux")
+
+
+@for_one_database
+def test_connect_with_connection_string(dsn, configuration):
+    connection_string = "DSN=%s;" % dsn
+    for para, val in get_credentials(configuration).items():
+        connection_string = connection_string + "%s=%s;" % (para, val)
+    connection = connect(connection_string=connection_string)
+    connection.cursor().execute("SELECT 'foo'")
+    connection.close()

--- a/python/turbodbc_test/test_connect.py
+++ b/python/turbodbc_test/test_connect.py
@@ -1,6 +1,6 @@
 import pytest
 
-from turbodbc import connect, DatabaseError
+from turbodbc import connect, DatabaseError, ParameterError
 from turbodbc.connect import _make_connection_string
 from turbodbc.connection import Connection
 
@@ -49,3 +49,10 @@ def test_connect_raises_on_invalid_additional_option(dsn, configuration):
     additional_option = {configuration['capabilities']['connection_user_option']: 'invalid user'}
     with pytest.raises(DatabaseError):
         connect(dsn=dsn, **additional_option)
+
+
+def test_connect_raises_on_ambiguous_parameters():
+    with pytest.raises(ParameterError):
+        connect("foo", connection_string="DRIVER=bar;SERVER=baz;")
+    with pytest.raises(ParameterError):
+        connect(connection_string="DRIVER=foo;SERVER=bar;", baz="qux")


### PR DESCRIPTION
Moving from ceODBC to turbodbc can be quite annoying since ceODBC only supports preformatted strings.
It also looks like pyodbc [currently recommends](https://github.com/mkleehammer/pyodbc/wiki/Connecting-to-databases) preformatted strings.
This makes it easier.