### PR TITLE
api docs formatting and other tweaks

### DIFF
--- a/python/turbodbc/connect.py
+++ b/python/turbodbc/connect.py
@@ -20,14 +20,15 @@ def connect(dsn=None, turbodbc_options=None, read_buffer_size=None, parameter_se
     """
     Create a connection with the database identified by the ``dsn`` or the ``connection_string``.
 
-    :param dsn: Data source name as given in the odbc.ini file
-    :param turbodbc_options: Options that control how turbodbc interacts with the database.\
+    :param dsn: Data source name as given in the (unix) odbc.ini file
+           or (Windows) ODBC Data Source Administrator tool.
+    :param turbodbc_options: Options that control how turbodbc interacts with the database.
            Create such a struct with `turbodbc.make_options()` or leave this blank to take the defaults.
-    :param connection_string: Preformatted ODBC connection string.\
+    :param connection_string: Preformatted ODBC connection string.
            Specifying this and dsn or kwargs at the same time raises ParameterError.
-    :param \**kwargs: You may specify additional options as you please. These options will go into\
-           the connection string that identifies the database. Valid options depend on the specific database you\
-           would like to connect with (e.g. `user` and `password` or `uid` and `pwd`)
+    :param \**kwargs: You may specify additional options as you please. These options will go into
+           the connection string that identifies the database. Valid options depend on the specific database you
+           would like to connect with (e.g. `user` and `password`, or `uid` and `pwd`)
     :return: A connection to your database
     """
     if turbodbc_options is None:

--- a/python/turbodbc/connection.py
+++ b/python/turbodbc/connection.py
@@ -17,7 +17,7 @@ class Connection(object):
     def cursor(self):
         """
         Create a new ``Cursor`` instance associated with this ``Connection``
-        
+
         :return: A new ``Cursor`` instance
         """
         self._assert_valid()
@@ -36,7 +36,7 @@ class Connection(object):
     @translate_exceptions
     def rollback(self):
         """
-        Roll back all changes in the current transaction 
+        Roll back all changes in the current transaction
         """
         self._assert_valid()
         self.impl.rollback()
@@ -44,7 +44,7 @@ class Connection(object):
     def close(self):
         """
         Close the connection and all associated cursors. This will implicitly
-        roll back any uncommited operations.
+        roll back any uncommitted operations.
         """
         for c in self.cursors:
             c.close()

--- a/python/turbodbc/cursor.py
+++ b/python/turbodbc/cursor.py
@@ -61,7 +61,7 @@ class Cursor(object):
     def description(self):
         """
         Retrieve a description of the columns in the current result set
-        
+
         :return: A tuple of seven elements. Only some elements are meaningful:\n
                  *   Element #0 is the name of the column
                  *   Element #1 is the type code of the column
@@ -77,13 +77,13 @@ class Cursor(object):
     def execute(self, sql, parameters=None):
         """
         Execute an SQL command or query
-        :param sql: A (unicode) string the contains the SQL command or query. If you would like to\
-               use parameters, please use a question mark ``?`` at the location where the\
+
+        :param sql: A (unicode) string that contains the SQL command or query. If you would like to
+               use parameters, please use a question mark ``?`` at the location where the
                parameter shall be inserted.
-        :param parameters: An iterable of parameter values. The number of values must match\
+        :param parameters: An iterable of parameter values. The number of values must match
                the number of parameters in the SQL string.
-        
-        :return: Returns the ``Cursor`` object to allow chaining of operations.
+        :return: The ``Cursor`` object to allow chaining of operations.
         """
         self.rowcount = -1
         self._assert_valid()
@@ -105,15 +105,15 @@ class Cursor(object):
     def executemany(self, sql, parameters=None):
         """
         Execute an SQL command or query with multiple parameter sets.
-        :param sql: A (unicode) string the contains the SQL command or query. If you would like to\
-               use parameters, please use a question mark ``?`` at the location where the\
+
+        :param sql: A (unicode) string that contains the SQL command or query. If you would like to
+               use parameters, please use a question mark ``?`` at the location where the
                parameter shall be inserted.
-        :param parameters: An iterable of iterable of parameter values. The outer iterable represents\
-               separate parameter sets. The inner iterable contains parameter values for a given\
-               parameter set. The number of values of each set must match the number of parameters\
+        :param parameters: An iterable of iterable of parameter values. The outer iterable represents
+               separate parameter sets. The inner iterable contains parameter values for a given
+               parameter set. The number of values of each set must match the number of parameters
                in the SQL string.
-               
-        :return: Returns the ``Cursor`` object to allow chaining of operations.
+        :return: The ``Cursor`` object to allow chaining of operations.
         """
         self.rowcount = -1
         self._assert_valid()
@@ -137,9 +137,9 @@ class Cursor(object):
     @translate_exceptions
     def fetchone(self):
         """
-        Returns a single row of a result set. Requires an active result set on the database\
+        Returns a single row of a result set. Requires an active result set on the database
         generated with ``execute()`` or ``executemany()``.
-        
+
         :return: Returns ``None`` when no more rows are available in the result set
         """
         self._assert_valid_result_set()
@@ -152,22 +152,22 @@ class Cursor(object):
     @translate_exceptions
     def fetchall(self):
         """
-        Fetches a list of all rows in the active result set generated with ``execute()`` or\
+        Fetches a list of all rows in the active result set generated with ``execute()`` or
         ``executemany()``.
-        
-        :return: Returns a list of rows
+
+        :return: A list of rows
         """
         return [row for row in self]
 
     @translate_exceptions
     def fetchmany(self, size=None):
         """
-        Fetches a batch of rows in the active result set generated with ``execute()`` or\
+        Fetches a batch of rows in the active result set generated with ``execute()`` or
         ``executemany()``.
-        :param size: Controls how many rows are returned. The default ``None`` means that\
+
+        :param size: Controls how many rows are returned. The default ``None`` means that
                the value of Cursor.arraysize is used.
-        
-        :return: Returns a list of rows
+        :return: A list of rows
         """
         if size is None:
             size = self.arraysize
@@ -178,12 +178,12 @@ class Cursor(object):
 
     def fetchallnumpy(self):
         """
-        Fetches all rows in the active result set generated with ``execute()`` or\
+        Fetches all rows in the active result set generated with ``execute()`` or
         ``executemany()``.
-        
-        :return: An ``OrderedDict`` of *columns*, where the keys of the dictionary\
-                 are the column names. The columns are of NumPy's ``MaskedArray``\
-                 type, where the optimal data type for each result set column is\
+
+        :return: An ``OrderedDict`` of *columns*, where the keys of the dictionary
+                 are the column names. The columns are of NumPy's ``MaskedArray``
+                 type, where the optimal data type for each result set column is
                  chosen automatically.
         """
         from numpy.ma import concatenate
@@ -193,11 +193,11 @@ class Cursor(object):
 
     def fetchnumpybatches(self):
         """
-        Returns an iterator over all rows in the active result set generated with ``execute()`` or\
+        Returns an iterator over all rows in the active result set generated with ``execute()`` or
         ``executemany()``.
-        
-        :return: An iterator you can use to iterate over batches of rows of the result set. Each\
-                 batch consists of an ``OrderedDict`` of NumPy ``MaskedArray`` instances. See\
+
+        :return: An iterator you can use to iterate over batches of rows of the result set. Each
+                 batch consists of an ``OrderedDict`` of NumPy ``MaskedArray`` instances. See
                  ``fetchallnumpy()`` for details.
         """
         batchgen = self._numpy_batch_generator()
@@ -224,7 +224,7 @@ class Cursor(object):
 
     def close(self):
         """
-        Closes the cursor. 
+        Close the cursor.
         """
         self.result_set = None
         self.impl = None


### PR DESCRIPTION
- remove unnecessary line continuation markers
- correct the reStructuredText formatting of some parameter descriptions
- add reference to the Windows Data Source Administrator
- other minor typos and spelling corrections

The HTML docs have been re-generated using sphinx-build and they look OK to me.