### PR TITLE
Add autocommit options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 Version 1.1.2 (unreleased)
 ==========================
+*   Add `autocommit` as a keyword argument to `make_options()`. As the
+    name suggests, this allows you to enable automatic `COMMIT` operations
+    after each operation. It also improves compatibility with databases
+    that do not support transactions.
 *   Fixed bug with `cursor.rowcount` not being reset to `-1` when calls to
     `execute()` or `executemany()` raised exceptions.
 *   Fixed bug with `cursor.rowcount` not showing the correct value when

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 Version 1.1.2 (unreleased)
 ==========================
-*   Add `autocommit` as a keyword argument to `make_options()`. As the
+*   Added `autocommit` as a keyword argument to `make_options()`. As the
     name suggests, this allows you to enable automatic `COMMIT` operations
     after each operation. It also improves compatibility with databases
     that do not support transactions.
+*   Added `autocommit` property to `Connection` class that allows switching
+    autocommit mode after the connection was created.
 *   Fixed bug with `cursor.rowcount` not being reset to `-1` when calls to
     `execute()` or `executemany()` raised exceptions.
 *   Fixed bug with `cursor.rowcount` not showing the correct value when

--- a/cpp/turbodbc/Library/src/configuration.cpp
+++ b/cpp/turbodbc/Library/src/configuration.cpp
@@ -8,7 +8,8 @@ options::options() :
     read_buffer_size(megabytes(20)),
     parameter_sets_to_buffer(1000),
     use_async_io(false),
-    prefer_unicode(false)
+    prefer_unicode(false),
+    autocommit(false)
 {
 }
 

--- a/cpp/turbodbc/Library/src/connection.cpp
+++ b/cpp/turbodbc/Library/src/connection.cpp
@@ -8,7 +8,11 @@ connection::connection(std::shared_ptr<cpp_odbc::connection const> low_level_con
     connection_(low_level_connection),
     configuration(std::move(options), capabilities(*connection_))
 {
-    connection_->set_attribute(SQL_ATTR_AUTOCOMMIT, SQL_AUTOCOMMIT_OFF);
+    if (configuration.options.autocommit) {
+        connection_->set_attribute(SQL_ATTR_AUTOCOMMIT, SQL_AUTOCOMMIT_ON);
+    } else {
+        connection_->set_attribute(SQL_ATTR_AUTOCOMMIT, SQL_AUTOCOMMIT_OFF);
+    }
 }
 
 void connection::commit() const

--- a/cpp/turbodbc/Library/src/connection.cpp
+++ b/cpp/turbodbc/Library/src/connection.cpp
@@ -25,6 +25,21 @@ void connection::rollback() const
     connection_->rollback();
 }
 
+void connection::set_autocommit(bool enabled)
+{
+    if (enabled) {
+        connection_->set_attribute(SQL_ATTR_AUTOCOMMIT, SQL_AUTOCOMMIT_ON);
+    } else {
+        connection_->set_attribute(SQL_ATTR_AUTOCOMMIT, SQL_AUTOCOMMIT_OFF);
+    }
+    configuration.options.autocommit = enabled;
+}
+
+bool connection::autocommit_enabled() const
+{
+    return configuration.options.autocommit;
+}
+
 cursor connection::make_cursor() const
 {
     return {connection_, configuration};

--- a/cpp/turbodbc/Library/turbodbc/configuration.h
+++ b/cpp/turbodbc/Library/turbodbc/configuration.h
@@ -11,6 +11,7 @@ struct options {
     std::size_t parameter_sets_to_buffer;
     bool use_async_io;
     bool prefer_unicode;
+    bool autocommit;
 };
 
 struct capabilities {

--- a/cpp/turbodbc/Library/turbodbc/connection.h
+++ b/cpp/turbodbc/Library/turbodbc/connection.h
@@ -34,6 +34,17 @@ public:
     void rollback() const;
 
     /**
+     * @brief Enable or disable autocommit mode
+     * @param enabled Set to true to enable autocommit
+     */
+    void set_autocommit(bool enabled);
+
+    /**
+     * @brief Returns whether autocommit is currently enabled
+     */
+    bool autocommit_enabled() const;
+
+    /**
      * @brief Create a new cursor object associated with this connection
      */
     turbodbc::cursor make_cursor() const;

--- a/cpp/turbodbc/Test/tests/configuration_test.cpp
+++ b/cpp/turbodbc/Test/tests/configuration_test.cpp
@@ -15,6 +15,7 @@ TEST(ConfigurationTest, OptionsDefaults)
     EXPECT_EQ(options.parameter_sets_to_buffer, 1000);
     EXPECT_FALSE(options.use_async_io);
     EXPECT_FALSE(options.prefer_unicode);
+    EXPECT_FALSE(options.autocommit);
 }
 
 

--- a/cpp/turbodbc/Test/tests/connection_test.cpp
+++ b/cpp/turbodbc/Test/tests/connection_test.cpp
@@ -33,6 +33,37 @@ TEST(ConnectionTest, ConstructorEnablesAutoCommit)
 }
 
 
+TEST(ConnectionTest, SetAutocommit)
+{
+    auto connection = std::make_shared<mock_connection>();
+    {
+        testing::InSequence dummy;
+
+        EXPECT_CALL(*connection, do_set_attribute(SQL_ATTR_AUTOCOMMIT, SQL_AUTOCOMMIT_OFF))
+            .Times(1).RetiresOnSaturation();
+        EXPECT_CALL(*connection, do_set_attribute(SQL_ATTR_AUTOCOMMIT, SQL_AUTOCOMMIT_ON))
+            .Times(1).RetiresOnSaturation();
+        EXPECT_CALL(*connection, do_set_attribute(SQL_ATTR_AUTOCOMMIT, SQL_AUTOCOMMIT_OFF))
+            .Times(1).RetiresOnSaturation();
+    }
+    turbodbc::connection test_connection(connection, turbodbc::options());
+    test_connection.set_autocommit(true);
+    test_connection.set_autocommit(false);
+}
+
+TEST(ConnectionTest, GetAutocommit)
+{
+    auto connection = std::make_shared<mock_connection>();
+
+    turbodbc::connection test_connection(connection, turbodbc::options());
+    EXPECT_FALSE(test_connection.autocommit_enabled());
+    test_connection.set_autocommit(true);
+    EXPECT_TRUE(test_connection.autocommit_enabled());
+    test_connection.set_autocommit(false);
+    EXPECT_FALSE(test_connection.autocommit_enabled());
+}
+
+
 TEST(ConnectionTest, Commit)
 {
     auto connection = std::make_shared<mock_connection>();

--- a/cpp/turbodbc/Test/tests/connection_test.cpp
+++ b/cpp/turbodbc/Test/tests/connection_test.cpp
@@ -16,8 +16,22 @@ TEST(ConnectionTest, ConstructorDisablesAutoCommit)
     auto connection = std::make_shared<mock_connection>();
     EXPECT_CALL(*connection, do_set_attribute(SQL_ATTR_AUTOCOMMIT, SQL_AUTOCOMMIT_OFF)).Times(1);
 
-    turbodbc::connection test_connection(connection, turbodbc::options());
+    turbodbc::options options;
+    options.autocommit = false;
+    turbodbc::connection test_connection(connection, options);
 }
+
+
+TEST(ConnectionTest, ConstructorEnablesAutoCommit)
+{
+    auto connection = std::make_shared<mock_connection>();
+    EXPECT_CALL(*connection, do_set_attribute(SQL_ATTR_AUTOCOMMIT, SQL_AUTOCOMMIT_ON)).Times(1);
+
+    turbodbc::options options;
+    options.autocommit = true;
+    turbodbc::connection test_connection(connection, options);
+}
+
 
 TEST(ConnectionTest, Commit)
 {

--- a/cpp/turbodbc_python/Library/src/python_bindings/connection.cpp
+++ b/cpp/turbodbc_python/Library/src/python_bindings/connection.cpp
@@ -9,7 +9,11 @@ void for_connection(pybind11::module &module) {
     pybind11::class_<turbodbc::connection>(module, "Connection")
         .def("commit", &turbodbc::connection::commit)
         .def("rollback", &turbodbc::connection::rollback)
-        .def("cursor", &turbodbc::connection::make_cursor);
+        .def("cursor", &turbodbc::connection::make_cursor)
+        .def("set_autocommit", &turbodbc::connection::set_autocommit)
+        .def("autocommit_enabled", &turbodbc::connection::autocommit_enabled)
+        ;
+
 }
 
 } }

--- a/cpp/turbodbc_python/Library/src/python_bindings/options.cpp
+++ b/cpp/turbodbc_python/Library/src/python_bindings/options.cpp
@@ -66,6 +66,7 @@ void for_options(pybind11::module & module)
         .def_readwrite("parameter_sets_to_buffer", &turbodbc::options::parameter_sets_to_buffer)
         .def_readwrite("use_async_io", &turbodbc::options::use_async_io)
         .def_readwrite("prefer_unicode", &turbodbc::options::prefer_unicode)
+        .def_readwrite("autocommit", &turbodbc::options::autocommit)
     ;
 
 }

--- a/docs/pages/advanced_usage.rst
+++ b/docs/pages/advanced_usage.rst
@@ -5,8 +5,8 @@ Advanced usage
 
 .. _advanced_usage_options:
 
-Performance and compatibility options
--------------------------------------
+Performance, compatibility, and behavior options
+------------------------------------------------
 
 Turbodbc offers a way to adjust its behavior to tune performance and to
 achieve compatibility with your database. The basic usage is this:
@@ -27,6 +27,7 @@ options, supply keyword arguments to ``make_options()``:
     ...                        parameter_sets_to_buffer=1000,
     ...                        use_async_io=True,
     ...                        prefer_unicode=True)
+    ...                        autocommit=True)
 
 
 .. _advanced_usage_options_read_buffer:
@@ -76,11 +77,22 @@ operations.
 Prefer unicode
 ~~~~~~~~~~~~~~
 
-Finally, set ``prefer_unicode`` to ``True`` if your database does not fully support
+Set ``prefer_unicode`` to ``True`` if your database does not fully support
 the UTF-8 encoding turbodbc prefers. With this option you can tell turbodbc
 to use two-byte character strings with UCS-2/UTF-16 encoding. Use this option
 if you try to connection to Microsoft SQL server (MSSQL).
 
+Autocommit
+~~~~~~~~~~
+
+Set ``autocommit`` to ``True`` if you want the database to ``COMMIT`` your
+changes automatically after each query or command. By default, ``autocommit``
+is disabled and users are required to call ``cursor.commit()`` to persist
+their changes.
+
+.. note::
+    Some databases that do not support transactions may even require this
+    option to be set to ``True`` in order to establish a connection at all.
 
 
 NumPy support

--- a/docs/pages/advanced_usage.rst
+++ b/docs/pages/advanced_usage.rst
@@ -95,6 +95,24 @@ their changes.
     option to be set to ``True`` in order to establish a connection at all.
 
 
+Controlling autocommit behavior at runtime
+------------------------------------------
+
+You can enable and disable autocommit mode after you have established a connection,
+and you can also check whether autocommit is currently enabled:
+
+::
+
+    >>> from turbodbc import connect
+    >>> connection = connect(dsn="my DSN")
+    >>> connection.autocommit = True
+
+    [... more things happening ...]
+
+    >>> if not connection.autocommit:
+    ...     connection.commit()
+
+
 NumPy support
 -------------
 

--- a/python/turbodbc/connection.py
+++ b/python/turbodbc/connection.py
@@ -50,3 +50,15 @@ class Connection(object):
             c.close()
         self.cursors = []
         self.impl = None
+
+    @property
+    def autocommit(self):
+        """
+        This attribute controls whether changes are automatically committed after each
+        execution or not.
+        """
+        return self.impl.autocommit_enabled()
+
+    @autocommit.setter
+    def autocommit(self, value):
+        self.impl.set_autocommit(value)

--- a/python/turbodbc/options.py
+++ b/python/turbodbc/options.py
@@ -3,7 +3,8 @@ from turbodbc_intern import Options
 def make_options(read_buffer_size=None,
                  parameter_sets_to_buffer=None,
                  prefer_unicode=None,
-                 use_async_io=None):
+                 use_async_io=None,
+                 autocommit=None):
     """
     Create options that control how turbodbc interacts with a database. These
     options affect performance for the most part, but some options may require adjustment
@@ -23,6 +24,10 @@ def make_options(read_buffer_size=None,
      strings encoded with UTF-8, leading to UTF-8 characters being misinterpreted, misrepresented, or
      downright rejected. Set this option to `True` if you want to transfer character data using the
      UCS-2/UCS-16 encoding that use (multiple) two-byte instead of (multiple) one-byte characters.
+    :param autocommit: Affects behavior. If set to `True`, all queries and commands executed
+     with `cursor.execute()` or `cursor.executemany()` will be succeeded by an implicit `commit`
+     operation, persisting any changes made to the database. If not set or set to `False`,
+     users has to take care of calling `cursor.commit()` themselves.
     :return: An option struct that is suitable to pass to the `turbodbc_options` parameter of
      `turbodbc.connect()`
     """
@@ -39,5 +44,8 @@ def make_options(read_buffer_size=None,
 
     if not use_async_io is None:
         options.use_async_io = use_async_io
+
+    if not autocommit is None:
+        options.autocommit = autocommit
 
     return options

--- a/python/turbodbc_test/query_fixture.py
+++ b/python/turbodbc_test/query_fixture.py
@@ -3,6 +3,9 @@ from contextlib import contextmanager
 import random
 
 
+def unique_table_name():
+    return 'test_{}'.format(random.randint(0, 1000000000))
+
 @contextmanager
 def query_fixture(cursor, configuration, fixture_key):
     """
@@ -50,7 +53,7 @@ def query_fixture(cursor, configuration, fixture_key):
     "{table_name}" to be replaced with a random table (or view) name.
     """
     fixture = configuration['queries'][fixture_key]
-    table_name = table_name = 'test_{}'.format(random.randint(0, 1000000000))
+    table_name = unique_table_name()
     
     def _execute_queries(queries, replacements):
         if not isinstance(queries, list):

--- a/python/turbodbc_test/test_options.py
+++ b/python/turbodbc_test/test_options.py
@@ -10,11 +10,13 @@ def test_options_with_overrides():
     options = make_options(read_buffer_size=Rows(123),
                            parameter_sets_to_buffer=2500,
                            prefer_unicode=True,
-                           use_async_io=True)
+                           use_async_io=True,
+                           autocommit=True)
 
     assert options.read_buffer_size.rows == 123
     assert options.parameter_sets_to_buffer == 2500
     assert options.prefer_unicode == True
     assert options.use_async_io == True
+    assert options.autocommit == True
 
 


### PR DESCRIPTION
Added autocommit options when establishing connections via `turbodbc.make_options()` and while having an active connection via `Connection.autocommit`.

Fixes #41 and probably also fixes #87.