### PR TITLE
Add Docker setup to build and run the integration tests

### DIFF
--- a/cmake_scripts/FindArrow.cmake
+++ b/cmake_scripts/FindArrow.cmake
@@ -47,6 +47,10 @@ if (NOT ARROW_HOME)
     find_path(ARROW_INCLUDE_DIR arrow/api.h HINTS
       $ENV{VIRTUAL_ENV}/lib/*/site-packages/pyarrow/include)
     get_filename_component(ARROW_SEARCH_LIB_PATH ${ARROW_INCLUDE_DIR} DIRECTORY)
+  else()
+    find_path(ARROW_INCLUDE_DIR arrow/api.h HINTS
+      /usr/local/lib/*/dist-packages/pyarrow/include)
+    get_filename_component(ARROW_SEARCH_LIB_PATH ${ARROW_INCLUDE_DIR} DIRECTORY)
   endif()
 else()
   set(ARROW_SEARCH_HEADER_PATHS

--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -1,0 +1,13 @@
+FROM ubuntu:trusty
+
+RUN apt-get update
+RUN apt-get dist-upgrade -y
+# These are dependencies that are installed on Travis but not in the base Docker image
+RUN apt-get install -y python-pip ninja-build cmake git-core wget
+RUN apt-get install -y unixodbc unixodbc-dev
+RUN apt-get install -y libboost-all-dev
+RUN apt-get install -y mysql-server-5.6 mysql-client-core-5.6 mysql-client-5.6 libmyodbc
+RUN apt-get install -y postgresql odbc-postgresql=1:09.02.0100-2ubuntu1
+
+RUN pip install -U pip setuptools setuptools_scm
+RUN pip install -U numpy==1.10.4 pyarrow==0.4.0 pybind11 pytest pytest-cov mock six

--- a/contrib/docker/build_and_test.sh
+++ b/contrib/docker/build_and_test.sh
@@ -1,0 +1,3 @@
+#/bin/bash
+
+docker run --rm -t -i -v $PWD:/io turbodbc_base /io/contrib/docker/build_and_test_in_docker.sh

--- a/contrib/docker/build_and_test_in_docker.sh
+++ b/contrib/docker/build_and_test_in_docker.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -ex
+
+pushd /io
+
+export ODBCSYSINI=`pwd`/travis/odbc
+export TURBODBC_TEST_CONFIGURATION_FILES="query_fixtures_postgresql.json,query_fixtures_mysql.json"
+
+/etc/init.d/mysql start
+mysql -u root -e 'CREATE DATABASE test_db;'
+
+/etc/init.d/postgresql start
+sudo -u postgres psql -U postgres -c 'CREATE DATABASE test_db;'
+sudo -u postgres psql -U postgres -c "ALTER USER postgres WITH PASSWORD 'password';"
+
+mkdir -p build_docker && cd build_docker
+cmake -DCMAKE_INSTALL_PREFIX=./dist -DPYBIND11_PYTHON_VERSION=2.7 ..
+make -j5
+ctest --verbose

--- a/contrib/docker/build_image.sh
+++ b/contrib/docker/build_image.sh
@@ -1,0 +1,6 @@
+#/bin/bash
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+pushd ${SCRIPT_DIR}
+
+docker build -t turbodbc_base -f Dockerfile .

--- a/google_test/build_google_test.sh
+++ b/google_test/build_google_test.sh
@@ -2,9 +2,10 @@
 FLAGS=$1
 
 echo "Cloning latest google test repository"
-git clone https://github.com/google/googletest.git
+wget https://github.com/google/googletest/archive/release-1.8.0.tar.gz -O googletest-1.8.0.tar.gz
+tar xf googletest-1.8.0.tar.gz
 
 mkdir build
 cd build
-cmake ../googletest -DCMAKE_INSTALL_PREFIX=../dist -DCMAKE_CXX_FLAGS="${FLAGS}"
+cmake ../googletest-release-1.8.0 -DCMAKE_INSTALL_PREFIX=../dist -DCMAKE_CXX_FLAGS="${FLAGS}"
 cmake --build . --target install


### PR DESCRIPTION
This also fixes:

 * Latest gtest master uses different installation dirs, this PR pins
   gtest to version 1.8
 * Added the possibility to find system-wide Arrow installations