### PR TITLE
Interpret Arrow results as stolen references

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,12 @@ Version history / changelog
 
 From version 2.0.0, turbodbc adapts semantic versioning.
 
+Version 2.4.1
+-------------
+
+*   Fixed a memory leak on ``fetchallarrow()`` that increased the reference
+    count of the returned table by one too much.
+
 Version 2.4.0
 -------------
 

--- a/cpp/turbodbc_arrow/Library/src/arrow_result_set.cpp
+++ b/cpp/turbodbc_arrow/Library/src/arrow_result_set.cpp
@@ -236,7 +236,7 @@ pybind11::object arrow_result_set::fetch_all()
     }
 
     arrow::py::import_pyarrow();
-    return pybind11::reinterpret_borrow<pybind11::object>(pybind11::handle(arrow::py::wrap_table(table)));
+    return pybind11::reinterpret_steal<pybind11::object>(pybind11::handle(arrow::py::wrap_table(table)));
 }
 
 

--- a/python/turbodbc_test/test_select_arrow.py
+++ b/python/turbodbc_test/test_select_arrow.py
@@ -2,7 +2,9 @@ from collections import OrderedDict
 from mock import patch
 
 import datetime
+import gc
 import pytest
+import sys
 import turbodbc
 
 from query_fixture import query_fixture
@@ -54,6 +56,8 @@ def test_arrow_empty_column(dsn, configuration):
             assert isinstance(result, pa.Table)
             assert result.num_columns == 1
             assert result.num_rows == 0
+            gc.collect()
+            assert sys.getrefcount(result) == 2
 
 
 @for_each_database

--- a/python/turbodbc_test/test_select_arrow.py
+++ b/python/turbodbc_test/test_select_arrow.py
@@ -56,6 +56,15 @@ def test_arrow_empty_column(dsn, configuration):
             assert isinstance(result, pa.Table)
             assert result.num_columns == 1
             assert result.num_rows == 0
+
+
+@for_each_database
+@pyarrow
+def test_arrow_reference_count(dsn, configuration):
+    with open_cursor(configuration) as cursor:
+        with query_fixture(cursor, configuration, 'INSERT INTEGER') as table_name:
+            cursor.execute("SELECT a FROM {}".format(table_name))
+            result = cursor.fetchallarrow()
             gc.collect()
             assert sys.getrefcount(result) == 2
 


### PR DESCRIPTION
This fixes the current memory leak on using Arrow results.