### PR TITLE
Arrow 0.8.0 version update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,7 +83,7 @@ before_install: |
   fi
 
 install:
-  - pip install numpy==1.10.4 pyarrow==0.7.0 six twine pytest-cov coveralls pandas
+  - pip install numpy==1.10.4 pyarrow==0.8.0 six twine pytest-cov coveralls pandas
 
 before_script: |
   if [ "$TRAVIS_OS_NAME" == "linux" ]; then

--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -10,4 +10,4 @@ RUN apt-get install -y mysql-server-5.6 mysql-client-core-5.6 mysql-client-5.6 l
 RUN apt-get install -y postgresql odbc-postgresql=1:09.02.0100-2ubuntu1
 
 RUN pip install -U pip setuptools setuptools_scm
-RUN pip install -U numpy==1.10.4 pyarrow==0.7.0 pybind11==2.2.0 pytest pytest-cov mock six pandas
+RUN pip install -U numpy==1.10.4 pyarrow==0.8.0 pybind11==2.2.0 pytest pytest-cov mock six pandas==0.20.0

--- a/cpp/turbodbc_arrow/Library/src/arrow_result_set.cpp
+++ b/cpp/turbodbc_arrow/Library/src/arrow_result_set.cpp
@@ -36,24 +36,24 @@ std::unique_ptr<ArrayBuilder> make_array_builder(turbodbc::type_code type, bool 
 {
     switch (type) {
         case turbodbc::type_code::floating_point:
-            return std::unique_ptr<ArrayBuilder>(new DoubleBuilder(default_memory_pool(), arrow::float64()));
+            return std::unique_ptr<ArrayBuilder>(new DoubleBuilder());
         case turbodbc::type_code::integer:
             if (adaptive_integers) {
-                return std::unique_ptr<ArrayBuilder>(new AdaptiveIntBuilder(default_memory_pool()));
+                return std::unique_ptr<ArrayBuilder>(new AdaptiveIntBuilder());
             } else {
-                return std::unique_ptr<ArrayBuilder>(new Int64Builder(default_memory_pool(), arrow::int64()));
+                return std::unique_ptr<ArrayBuilder>(new Int64Builder());
             }
         case turbodbc::type_code::boolean:
-            return std::unique_ptr<ArrayBuilder>(new BooleanBuilder(default_memory_pool(), std::make_shared<arrow::BooleanType>()));
+            return std::unique_ptr<ArrayBuilder>(new BooleanBuilder());
         case turbodbc::type_code::timestamp:
-            return std::unique_ptr<TimestampBuilder>(new TimestampBuilder(default_memory_pool(), arrow::timestamp(TimeUnit::MICRO)));
+            return std::unique_ptr<TimestampBuilder>(new TimestampBuilder(arrow::timestamp(TimeUnit::MICRO), ::arrow::default_memory_pool()));
         case turbodbc::type_code::date:
-            return std::unique_ptr<Date32Builder>(new Date32Builder(default_memory_pool()));
+            return std::unique_ptr<Date32Builder>(new Date32Builder());
         default:
             if (strings_as_dictionary) {
-                return std::unique_ptr<StringDictionaryBuilder>(new StringDictionaryBuilder(default_memory_pool()));
+                return std::unique_ptr<StringDictionaryBuilder>(new StringDictionaryBuilder(::arrow::utf8(), ::arrow::default_memory_pool()));
             } else {
-                return std::unique_ptr<StringBuilder>(new StringBuilder(default_memory_pool()));
+                return std::unique_ptr<StringBuilder>(new StringBuilder());
             }
     }
 }

--- a/cpp/turbodbc_arrow/Test/tests/arrow_result_set_test.cpp
+++ b/cpp/turbodbc_arrow/Test/tests/arrow_result_set_test.cpp
@@ -185,7 +185,7 @@ TEST_F(ArrowResultSetTest, AllTypesSchemaConversion)
 TEST_F(ArrowResultSetTest, SingleBatchSingleColumnResultSetConversion)
 {
     // Expected output: a Table with a single column of int64s
-    arrow::Int64Builder builder(pool, arrow::int64());
+    arrow::Int64Builder builder;
     for (int64_t i = 0; i < OUTPUT_SIZE; i++) {
         ASSERT_OK(builder.Append(i));
     }
@@ -195,7 +195,7 @@ TEST_F(ArrowResultSetTest, SingleBatchSingleColumnResultSetConversion)
     std::vector<std::shared_ptr<arrow::Field>> fields({std::make_shared<arrow::Field>("int_column", arrow::int64(), true)});
     std::shared_ptr<arrow::Schema> schema = std::make_shared<arrow::Schema>(fields);
     std::vector<std::shared_ptr<arrow::Column>> columns ({std::make_shared<arrow::Column>(fields[0], array)});
-    std::shared_ptr<arrow::Table> expected_table = std::make_shared<arrow::Table>(schema, columns);
+    std::shared_ptr<arrow::Table> expected_table = arrow::Table::Make(schema, columns);
 
     MockSchema({{"int_column", turbodbc::type_code::integer, size_unimportant, true}});
 
@@ -268,7 +268,7 @@ TEST_F(ArrowResultSetTest, MultiBatchConversionBoolean)
     cpp_odbc::multi_value_buffer buffer_1(sizeof(bool), OUTPUT_SIZE);
     cpp_odbc::multi_value_buffer buffer_1_2(sizeof(bool), OUTPUT_SIZE);
     {
-        arrow::BooleanBuilder builder(pool, arrow::boolean());
+        arrow::BooleanBuilder builder;
         for (int64_t i = 0; i < 2 * OUTPUT_SIZE; i++) {
             if (i % 5 == 0) {
                 ASSERT_OK(builder.AppendNull());
@@ -295,7 +295,7 @@ TEST_F(ArrowResultSetTest, MultiBatchConversionBoolean)
     cpp_odbc::multi_value_buffer buffer_2(sizeof(bool), OUTPUT_SIZE);
     cpp_odbc::multi_value_buffer buffer_2_2(sizeof(bool), OUTPUT_SIZE);
     {
-        arrow::BooleanBuilder builder(pool, arrow::boolean());
+        arrow::BooleanBuilder builder;
         for (int64_t i = 0; i < 2 * OUTPUT_SIZE; i++) {
             ASSERT_OK(builder.Append(i % 3 == 0));
             if (i < OUTPUT_SIZE) {
@@ -395,7 +395,7 @@ TEST_F(ArrowResultSetTest, MultiBatchConversionTimestamp)
     cpp_odbc::multi_value_buffer buffer_1(sizeof(SQL_TIMESTAMP_STRUCT), OUTPUT_SIZE);
     cpp_odbc::multi_value_buffer buffer_1_2(sizeof(SQL_TIMESTAMP_STRUCT), OUTPUT_SIZE);
     {
-        arrow::TimestampBuilder builder(pool, arrow::timestamp(arrow::TimeUnit::MICRO));
+        arrow::TimestampBuilder builder(arrow::timestamp(arrow::TimeUnit::MICRO), pool);
         for (int64_t i = 0; i < 2 * OUTPUT_SIZE; i++) {
             if (i % 5 == 0) {
                 ASSERT_OK(builder.AppendNull());
@@ -432,7 +432,7 @@ TEST_F(ArrowResultSetTest, MultiBatchConversionTimestamp)
     cpp_odbc::multi_value_buffer buffer_2(sizeof(SQL_TIMESTAMP_STRUCT), OUTPUT_SIZE);
     cpp_odbc::multi_value_buffer buffer_2_2(sizeof(SQL_TIMESTAMP_STRUCT), OUTPUT_SIZE);
     {
-        arrow::TimestampBuilder builder(pool, arrow::timestamp(arrow::TimeUnit::MICRO));
+        arrow::TimestampBuilder builder(arrow::timestamp(arrow::TimeUnit::MICRO), pool);
         for (int64_t i = 0; i < 2 * OUTPUT_SIZE; i++) {
             ASSERT_OK(builder.Append(i));
             auto td = boost::posix_time::microseconds(i);

--- a/python/turbodbc_test/test_executemanycolumns.py
+++ b/python/turbodbc_test/test_executemanycolumns.py
@@ -34,7 +34,7 @@ def _to_masked_columns(values, dtype, mask, column_backend):
     if column_backend == 'numpy':
         return [MaskedArray(values, mask=mask, dtype=dtype)]
     elif column_backend == 'arrow':
-        columns = pa.Array.from_pandas(array(values, dtype=dtype), mask=array(mask))
+        columns = pa.array(array(values, dtype=dtype), mask=array(mask))
         return pa.Table.from_arrays([columns], ['column'])
 
 

--- a/setup.py
+++ b/setup.py
@@ -209,7 +209,7 @@ setup(name = 'turbodbc',
       packages = ['turbodbc'],
       extras_require={
           # We pin Apache Arrow quite restrictively until they guarantee a stable API
-          'arrow': ['pyarrow>=0.7,<0.8'],
+          'arrow': ['pyarrow>=0.8,<0.9'],
           'numpy': 'numpy>=1.10.4'
       },
       classifiers = ['Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
Code changes that need to be done with `pyarrow==0.8.0`.  At the moment this is just for review.