### PR TITLE
Adding fix unicode allocation parameter  (related to #64)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,10 @@ Version 2.5.1 (UNRELEASED)
 *   Fixed a bug that lead to ``handle limit exceeded`` error messages when
     ``Cursor`` objects were not closed *manually*. With this fix, cursors
     are garbage collected as expected.
+*   Added new keyword argument ``force_extra_capacity_for_unicode`` to
+    ``make_options()``. If set to ``True``, memory allocation is modified
+    to operate under the assumption that the database driver reports field
+    lengths in characters, rather than code units (thanks @yaxxie).
 
 Version 2.5.0
 -------------

--- a/cpp/turbodbc/Library/src/configuration.cpp
+++ b/cpp/turbodbc/Library/src/configuration.cpp
@@ -12,7 +12,8 @@ options::options() :
     prefer_unicode(false),
     autocommit(false),
     large_decimals_as_64_bit_types(false),
-    limit_varchar_results_to_max(false)
+    limit_varchar_results_to_max(false),
+    fix_unicode_allocation(false)
 {
 }
 

--- a/cpp/turbodbc/Library/src/configuration.cpp
+++ b/cpp/turbodbc/Library/src/configuration.cpp
@@ -13,7 +13,7 @@ options::options() :
     autocommit(false),
     large_decimals_as_64_bit_types(false),
     limit_varchar_results_to_max(false),
-    fix_unicode_allocation(false)
+    force_extra_capacity_for_unicode(false)
 {
 }
 

--- a/cpp/turbodbc/Library/src/make_description.cpp
+++ b/cpp/turbodbc/Library/src/make_description.cpp
@@ -102,11 +102,11 @@ template <typename Description>
 std::unique_ptr<description> make_character_description(cpp_odbc::column_description const & source,
                                                         turbodbc::options const & options)
 {
-    int multiplier = (options.fix_unicode_allocation ? Description::multiplier : 1);
+    int const capacity_multiplier = (options.force_extra_capacity_for_unicode ? Description::max_code_units_per_unicode_code_point : 1);
     std::size_t const sanitized_size = (source.size == 0 ? options.varchar_max_character_limit : source.size);
     std::size_t const limited_size = (options.limit_varchar_results_to_max ?
                                       std::min(sanitized_size, options.varchar_max_character_limit) :
-                                      sanitized_size) * multiplier;
+                                      sanitized_size) * capacity_multiplier;
     return std::unique_ptr<description>(new Description(source.name,
                                                         source.allows_null_values,
                                                         limited_size));

--- a/cpp/turbodbc/Library/src/make_description.cpp
+++ b/cpp/turbodbc/Library/src/make_description.cpp
@@ -9,6 +9,7 @@
 #include <sstream>
 #include <algorithm>
 
+
 namespace turbodbc {
 
 namespace {
@@ -101,10 +102,11 @@ template <typename Description>
 std::unique_ptr<description> make_character_description(cpp_odbc::column_description const & source,
                                                         turbodbc::options const & options)
 {
+    int multiplier = (options.fix_unicode_allocation ? Description::multiplier : 1);
     std::size_t const sanitized_size = (source.size == 0 ? options.varchar_max_character_limit : source.size);
     std::size_t const limited_size = (options.limit_varchar_results_to_max ?
                                       std::min(sanitized_size, options.varchar_max_character_limit) :
-                                      sanitized_size);
+                                      sanitized_size) * multiplier;
     return std::unique_ptr<description>(new Description(source.name,
                                                         source.allows_null_values,
                                                         limited_size));

--- a/cpp/turbodbc/Library/turbodbc/configuration.h
+++ b/cpp/turbodbc/Library/turbodbc/configuration.h
@@ -15,6 +15,7 @@ struct options {
     bool autocommit;
     bool large_decimals_as_64_bit_types;
     bool limit_varchar_results_to_max;
+    bool fix_unicode_allocation;
 };
 
 struct capabilities {

--- a/cpp/turbodbc/Library/turbodbc/configuration.h
+++ b/cpp/turbodbc/Library/turbodbc/configuration.h
@@ -15,7 +15,7 @@ struct options {
     bool autocommit;
     bool large_decimals_as_64_bit_types;
     bool limit_varchar_results_to_max;
-    bool fix_unicode_allocation;
+    bool force_extra_capacity_for_unicode;
 };
 
 struct capabilities {

--- a/cpp/turbodbc/Library/turbodbc/descriptions/string_description.h
+++ b/cpp/turbodbc/Library/turbodbc/descriptions/string_description.h
@@ -9,7 +9,7 @@ namespace turbodbc {
  */
 class string_description : public description {
 public:
-	const static int multiplier = 4;
+	const static int max_code_units_per_unicode_code_point = 4;
 	string_description(std::size_t maximum_length);
 	string_description(std::string name, bool supports_null, std::size_t maximum_length);
 	~string_description();

--- a/cpp/turbodbc/Library/turbodbc/descriptions/string_description.h
+++ b/cpp/turbodbc/Library/turbodbc/descriptions/string_description.h
@@ -9,6 +9,7 @@ namespace turbodbc {
  */
 class string_description : public description {
 public:
+	const static int multiplier = 4;
 	string_description(std::size_t maximum_length);
 	string_description(std::string name, bool supports_null, std::size_t maximum_length);
 	~string_description();

--- a/cpp/turbodbc/Library/turbodbc/descriptions/unicode_description.h
+++ b/cpp/turbodbc/Library/turbodbc/descriptions/unicode_description.h
@@ -9,6 +9,7 @@ namespace turbodbc {
  */
 class unicode_description : public description {
 public:
+	const static int multiplier = 2;
 	unicode_description(std::size_t maximum_length);
 	unicode_description(std::string name, bool supports_null, std::size_t maximum_length);
 	~unicode_description();

--- a/cpp/turbodbc/Library/turbodbc/descriptions/unicode_description.h
+++ b/cpp/turbodbc/Library/turbodbc/descriptions/unicode_description.h
@@ -9,7 +9,7 @@ namespace turbodbc {
  */
 class unicode_description : public description {
 public:
-	const static int multiplier = 2;
+	const static int max_code_units_per_unicode_code_point = 2;
 	unicode_description(std::size_t maximum_length);
 	unicode_description(std::string name, bool supports_null, std::size_t maximum_length);
 	~unicode_description();

--- a/cpp/turbodbc_python/Library/src/python_bindings/options.cpp
+++ b/cpp/turbodbc_python/Library/src/python_bindings/options.cpp
@@ -70,6 +70,7 @@ void for_options(pybind11::module & module)
         .def_readwrite("autocommit", &turbodbc::options::autocommit)
         .def_readwrite("large_decimals_as_64_bit_types", &turbodbc::options::large_decimals_as_64_bit_types)
         .def_readwrite("limit_varchar_results_to_max", &turbodbc::options::limit_varchar_results_to_max)
+        .def_readwrite("fix_unicode_allocation", &turbodbc::options::fix_unicode_allocation)
     ;
 
 }

--- a/cpp/turbodbc_python/Library/src/python_bindings/options.cpp
+++ b/cpp/turbodbc_python/Library/src/python_bindings/options.cpp
@@ -70,7 +70,7 @@ void for_options(pybind11::module & module)
         .def_readwrite("autocommit", &turbodbc::options::autocommit)
         .def_readwrite("large_decimals_as_64_bit_types", &turbodbc::options::large_decimals_as_64_bit_types)
         .def_readwrite("limit_varchar_results_to_max", &turbodbc::options::limit_varchar_results_to_max)
-        .def_readwrite("fix_unicode_allocation", &turbodbc::options::fix_unicode_allocation)
+        .def_readwrite("force_extra_capacity_for_unicode", &turbodbc::options::force_extra_capacity_for_unicode)
     ;
 
 }

--- a/docs/pages/advanced_usage.rst
+++ b/docs/pages/advanced_usage.rst
@@ -155,6 +155,20 @@ If not set or set to ``False``, string-like result fields with a specific size w
 String-like fields of indeterminate size (``VARCHAR(max)``, ``TEXT``, etc. on some
 databases) are still subject to :ref:`advanced_usage_options_varchar_max`.
 
+.. _advanced_usage_options_limit_varchar_results:
+
+Extra capacity for unicode strings
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Set ``force_extra_capacity_for_unicode`` to ``True`` if  you find that strings retrieved
+from ``VARCHAR(n)`` or ``NVARCHAR(n)`` fields are being truncated. Some ODBC drivers report
+the length of the field and setting this option changes the way turbodbc allocates memory,
+so that retrieving these strings are not truncated. If ``limit_varchar_results_to_max`` is
+``True``, memory is allocated as if ``n`` is :ref:`advanced_usage_options_varchar_max`.
+
+Please note that enabling this option leads to increased memory usage when retrieving string
+fields in result sets. Parameters sent to the database are not affected by this option.
+
 
 Controlling autocommit behavior at runtime
 ------------------------------------------

--- a/python/turbodbc/options.py
+++ b/python/turbodbc/options.py
@@ -8,7 +8,7 @@ def make_options(read_buffer_size=None,
                  autocommit=None,
                  large_decimals_as_64_bit_types=None,
                  limit_varchar_results_to_max=None,
-                 fix_unicode_allocation=None):
+                 force_extra_capacity_for_unicode=None):
     """
     Create options that control how turbodbc interacts with a database. These
     options affect performance for the most part, but some options may require adjustment
@@ -53,10 +53,12 @@ def make_options(read_buffer_size=None,
      report a size of 2 billion characters.
      Please note that this option only relates to retrieving results, not sending parameters to the
      database.
-    :param fix_unicode_allocation Some ODBC drivers report the length of the varchar/nvarchar field rather
-     than the number of bytes which require to be allocated (e.g. utf8 in varchar fields requires more
-     bytes than the length of the field) -- this enables turbodbc to correctly allocate memory to
-     prevent string truncations
+    :param force_extra_capacity_for_unicode Affects behavior/performance. Some ODBC drivers report the
+     length of the ``VARCHAR``/``NVARCHAR`` field rather than the number of code points for which space is required
+     to be allocated, resulting in string truncations. Set this option to ``True`` to increase the memory
+     allocated for ``VARCHAR`` and ``NVARCHAR`` fields and prevent string truncations.
+     Please note that this option only relates to retrieving results, not sending parameters to the
+     database.
     :return: An option struct that is suitable to pass to the ``turbodbc_options`` parameter of
      ``turbodbc.connect()``
     """
@@ -86,7 +88,7 @@ def make_options(read_buffer_size=None,
     if not limit_varchar_results_to_max is None:
         options.limit_varchar_results_to_max = limit_varchar_results_to_max
 
-    if not fix_unicode_allocation is None:
-        options.fix_unicode_allocation = fix_unicode_allocation
+    if not force_extra_capacity_for_unicode is None:
+        options.force_extra_capacity_for_unicode = force_extra_capacity_for_unicode
 
     return options

--- a/python/turbodbc/options.py
+++ b/python/turbodbc/options.py
@@ -7,7 +7,8 @@ def make_options(read_buffer_size=None,
                  use_async_io=None,
                  autocommit=None,
                  large_decimals_as_64_bit_types=None,
-                 limit_varchar_results_to_max=None):
+                 limit_varchar_results_to_max=None,
+                 fix_unicode_allocation=None):
     """
     Create options that control how turbodbc interacts with a database. These
     options affect performance for the most part, but some options may require adjustment
@@ -52,6 +53,10 @@ def make_options(read_buffer_size=None,
      report a size of 2 billion characters.
      Please note that this option only relates to retrieving results, not sending parameters to the
      database.
+    :param fix_unicode_allocation Some ODBC drivers report the length of the varchar/nvarchar field rather
+     than the number of bytes which require to be allocated (e.g. utf8 in varchar fields requires more
+     bytes than the length of the field) -- this enables turbodbc to correctly allocate memory to
+     prevent string truncations
     :return: An option struct that is suitable to pass to the ``turbodbc_options`` parameter of
      ``turbodbc.connect()``
     """
@@ -80,5 +85,8 @@ def make_options(read_buffer_size=None,
 
     if not limit_varchar_results_to_max is None:
         options.limit_varchar_results_to_max = limit_varchar_results_to_max
+
+    if not fix_unicode_allocation is None:
+        options.fix_unicode_allocation = fix_unicode_allocation
 
     return options

--- a/python/turbodbc_test/test_options.py
+++ b/python/turbodbc_test/test_options.py
@@ -15,7 +15,7 @@ def test_options_with_overrides():
                            autocommit=True,
                            large_decimals_as_64_bit_types=True,
                            limit_varchar_results_to_max=True,
-                           fix_unicode_allocation=True)
+                           force_extra_capacity_for_unicode=True)
 
     assert options.read_buffer_size.rows == 123
     assert options.parameter_sets_to_buffer == 2500
@@ -25,4 +25,4 @@ def test_options_with_overrides():
     assert options.autocommit == True
     assert options.large_decimals_as_64_bit_types == True
     assert options.limit_varchar_results_to_max == True
-    assert options.fix_unicode_allocation == True
+    assert options.force_extra_capacity_for_unicode == True

--- a/python/turbodbc_test/test_options.py
+++ b/python/turbodbc_test/test_options.py
@@ -14,7 +14,8 @@ def test_options_with_overrides():
                            use_async_io=True,
                            autocommit=True,
                            large_decimals_as_64_bit_types=True,
-                           limit_varchar_results_to_max=True)
+                           limit_varchar_results_to_max=True,
+                           fix_unicode_allocation=True)
 
     assert options.read_buffer_size.rows == 123
     assert options.parameter_sets_to_buffer == 2500
@@ -24,3 +25,4 @@ def test_options_with_overrides():
     assert options.autocommit == True
     assert options.large_decimals_as_64_bit_types == True
     assert options.limit_varchar_results_to_max == True
+    assert options.fix_unicode_allocation == True


### PR DESCRIPTION
add fix_unicode_allocation parameter which changes the way memory gets allocated for strings if the ODBC driver presents the string length field rather then the number of bytes required

Sorry if some of the whitespace changes aren't to your liking, I'll fix them as required (it is my text editors defaults).

I want to note that I didn't do anything to do with unit tests so far (although I tested that the changes function as expected manually). 

I also appreciate that this implementation might not be as you are expecting, happy to receive feedback on that too. 

Other pull request for changes to decode UTF8 from WCHAR buffers will also come in due course.