### PR TITLE
Apache Arrow 0.11.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,7 +83,7 @@ before_install: |
   fi
 
 install:
-  - pip install numpy==1.10.4 pyarrow==0.8.0 six twine pytest-cov coveralls pandas
+  - pip install numpy==1.14.5 pyarrow==0.10.0 six twine pytest-cov coveralls pandas
 
 before_script: |
   if [ "$TRAVIS_OS_NAME" == "linux" ]; then
@@ -95,7 +95,7 @@ script:
   - mkdir build && cd build
   - cmake -DBUILD_COVERAGE=ON -DCMAKE_INSTALL_PREFIX=./dist -DPYBIND11_PYTHON_VERSION=${TRAVIS_PYTHON_VERSION} ..
   - make -j4
-  - pip install numpy==1.10.4
+  - pip install numpy==1.14.5
   - |
       if [ "$TRAVIS_OS_NAME" == "osx" ]; then
         ctest -E turbodbc_arrow_unit_test --verbose

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,12 +26,6 @@ matrix:
     - ODBC_DIR=odbc
   - os: linux
     language: python
-    python: "3.4"
-    env:
-    - TURBODBC_TEST_CONFIGURATION_FILES="query_fixtures_postgresql.json,query_fixtures_mysql.json"
-    - ODBC_DIR=odbc
-  - os: linux
-    language: python
     python: "3.5"
     env:
     - TURBODBC_TEST_CONFIGURATION_FILES="query_fixtures_postgresql.json,query_fixtures_mysql.json"

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,7 +77,7 @@ before_install: |
   fi
 
 install:
-  - pip install numpy==1.14.5 pyarrow==0.11.0 six twine pytest-cov coveralls pandas
+  - pip install numpy==1.14.5 pyarrow==0.11.1 six twine pytest-cov coveralls pandas
 
 before_script: |
   if [ "$TRAVIS_OS_NAME" == "linux" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,7 +77,7 @@ before_install: |
   fi
 
 install:
-  - pip install numpy==1.14.5 pyarrow==0.10.0 six twine pytest-cov coveralls pandas
+  - pip install numpy==1.14.5 pyarrow==0.11.0 six twine pytest-cov coveralls pandas
 
 before_script: |
   if [ "$TRAVIS_OS_NAME" == "linux" ]; then

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,11 +3,13 @@ Version history / changelog
 
 From version 2.0.0, turbodbc adapts semantic versioning.
 
-Version 2.7.1
+Version 3.0.0
 -------------
 
 *   Adjust generators to conform to PEP-479
 *   Build wheels for Python 3.7 on Windows
+*   Drop support for Python 3.4
+*   Update to Apache Arrow 0.11
 
 Version 2.7.0
 -------------

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ other popular ODBC modules do.
 
 Turbodbc is free to use ([MIT license](https://github.com/blue-yonder/turbodbc/blob/master/LICENSE)),
 open source ([GitHub](https://github.com/blue-yonder/turbodbc)),
-works with Python 2.7 and Python 3.4+, and is available for Linux, OSX, and Windows.
+works with Python 2.7 and Python 3.5+, and is available for Linux, OSX, and Windows.
 
 Turbodbc is routinely tested with [MySQL](https://www.mysql.com),
 [PostgreSQL](https://www.postgresql.org), [EXASOL](http://www.exasol.com),

--- a/cpp/turbodbc_arrow/Library/src/arrow_result_set.cpp
+++ b/cpp/turbodbc_arrow/Library/src/arrow_result_set.cpp
@@ -75,7 +75,7 @@ template <typename BuilderType>
 Status AppendIntsToBuilder(size_t rows_in_batch, std::unique_ptr<ArrayBuilder> const& builder, cpp_odbc::multi_value_buffer const& input_buffer, uint8_t* valid_bytes) {
     auto typed_builder = static_cast<BuilderType*>(builder.get());
     auto data_ptr = reinterpret_cast<const int64_t*>(input_buffer.data_pointer());
-    return typed_builder->Append(data_ptr, rows_in_batch, valid_bytes);
+    return typed_builder->AppendValues(data_ptr, rows_in_batch, valid_bytes);
 }
 
 }
@@ -117,7 +117,7 @@ std::shared_ptr<arrow::Schema> arrow_result_set::schema()
 Status append_to_double_builder(size_t rows_in_batch, std::unique_ptr<ArrayBuilder> const& builder, cpp_odbc::multi_value_buffer const& input_buffer, uint8_t* valid_bytes) {
     auto typed_builder = static_cast<DoubleBuilder*>(builder.get());
     auto data_ptr = reinterpret_cast<const double*>(input_buffer.data_pointer());
-    return typed_builder->Append(data_ptr, rows_in_batch, valid_bytes);
+    return typed_builder->AppendValues(data_ptr, rows_in_batch, valid_bytes);
 }
 
 Status append_to_int_builder(size_t rows_in_batch, std::unique_ptr<ArrayBuilder> const& builder, cpp_odbc::multi_value_buffer const& input_buffer, uint8_t* valid_bytes, bool adaptive_integers) {
@@ -131,7 +131,7 @@ Status append_to_int_builder(size_t rows_in_batch, std::unique_ptr<ArrayBuilder>
 Status append_to_bool_builder(size_t rows_in_batch, std::unique_ptr<ArrayBuilder> const& builder, cpp_odbc::multi_value_buffer const& input_buffer, uint8_t* valid_bytes) {
     auto typed_builder = static_cast<BooleanBuilder*>(builder.get());
     auto data_ptr = reinterpret_cast<const uint8_t*>(input_buffer.data_pointer());
-    return typed_builder->Append(data_ptr, rows_in_batch, valid_bytes);
+    return typed_builder->AppendValues(data_ptr, rows_in_batch, valid_bytes);
 }
 
 Status append_to_timestamp_builder(size_t rows_in_batch, std::unique_ptr<ArrayBuilder> const& builder, cpp_odbc::multi_value_buffer const& input_buffer, uint8_t*) {

--- a/cpp/turbodbc_arrow/Test/tests/arrow_result_set_test.cpp
+++ b/cpp/turbodbc_arrow/Test/tests/arrow_result_set_test.cpp
@@ -94,7 +94,7 @@ class ArrowResultSetTest : public ::testing::Test {
             EXPECT_OK(AllocateResizableBuffer(pool, data_nbytes, &data));
 
             // Fill with random data
-            arrow::test::random_bytes(data_nbytes, 0 /*random_seed*/, data->mutable_data());
+            arrow::random_bytes(data_nbytes, 0 /*random_seed*/, data->mutable_data());
 
             std::shared_ptr<arrow::ResizableBuffer> null_bitmap;
             const int64_t null_nbytes = arrow::BitUtil::BytesForBits(length);

--- a/cpp/turbodbc_arrow/Test/tests/arrow_result_set_test.cpp
+++ b/cpp/turbodbc_arrow/Test/tests/arrow_result_set_test.cpp
@@ -89,16 +89,16 @@ class ArrowResultSetTest : public ::testing::Test {
 
         template <typename ArrayType>
         std::shared_ptr<arrow::Array> MakePrimitive(int64_t length, int64_t null_count = 0) {
-            auto data = std::make_shared<arrow::PoolBuffer>(pool);
+            std::shared_ptr<arrow::ResizableBuffer> data;
             const int64_t data_nbytes = length * sizeof(typename ArrayType::value_type);
-            EXPECT_OK(data->Resize(data_nbytes));
+            EXPECT_OK(AllocateResizableBuffer(pool, data_nbytes, &data));
 
             // Fill with random data
             arrow::test::random_bytes(data_nbytes, 0 /*random_seed*/, data->mutable_data());
 
-            auto null_bitmap = std::make_shared<arrow::PoolBuffer>(pool);
+            std::shared_ptr<arrow::ResizableBuffer> null_bitmap;
             const int64_t null_nbytes = arrow::BitUtil::BytesForBits(length);
-            EXPECT_OK(null_bitmap->Resize(null_nbytes));
+            EXPECT_OK(AllocateResizableBuffer(pool, null_nbytes, &null_bitmap));
             memset(null_bitmap->mutable_data(), 255, null_nbytes);
             for (int64_t i = 0; i < null_count; i++) {
                 arrow::BitUtil::ClearBit(null_bitmap->mutable_data(), i * (length / null_count));

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,7 +19,7 @@ other popular ODBC modules do.
 
 Turbodbc is free to use (`MIT license <https://github.com/blue-yonder/turbodbc/blob/master/LICENSE>`_),
 open source (`GitHub <https://github.com/blue-yonder/turbodbc>`_),
-works with Python 2.7 and Python 3.4+, and is available for Linux, OSX, and Windows.
+works with Python 2.7 and Python 3.5+, and is available for Linux, OSX, and Windows.
 
 Turbodbc is routinely tested with `MySQL <https://www.mysql.com>`_,
 `PostgreSQL <https://www.postgresql.org>`_, `EXASOL <http://www.exasol.com>`_,

--- a/docs/pages/introduction.rst
+++ b/docs/pages/introduction.rst
@@ -20,7 +20,7 @@ Features
 *   Supported data types for both result sets and parameters:
     ``int``, ``float``, ``str``, ``bool``, ``datetime.date``, ``datetime.datetime``
 *   Also provides a high-level C++11 database driver under the hood
-*   Tested with Python 2.7, 3.4, 3.5, and 3.6
+*   Tested with Python 2.7, 3.5, and 3.6
 *   Tested on 64 bit versions of Linux, OSX, and Windows (Python 3.5+).
 
 
@@ -72,7 +72,7 @@ Supported environments
 *   Linux (successfully built on Ubuntu 12, Ubuntu 14, Debian 7, Debian 8)
 *   OSX (successfully built on Sierra a.k.a. 10.12 and El Capitan a.k.a. 10.11)
 *   Windows (successfully built on Windows 10)
-*   Python 2.7, 3.4, 3.5, 3.6
+*   Python 2.7, 3.5, 3.6
 *   More environments probably work as well, but these are the versions that
     are regularly tested on Travis or local development machines.
 

--- a/setup.py
+++ b/setup.py
@@ -216,8 +216,8 @@ setup(name = 'turbodbc',
       packages = ['turbodbc'],
       extras_require={
           # We pin Apache Arrow quite restrictively until they guarantee a stable API
-          'arrow': ['pyarrow>=0.8'],
-          'numpy': 'numpy>=1.10.4'
+          'arrow': ['pyarrow>=0.11,<0.12'],
+          'numpy': 'numpy>=1.14.0'
       },
       classifiers = ['Development Status :: 5 - Production/Stable',
                      'Intended Audience :: Developers',


### PR DESCRIPTION
This adds support for `pyarrow==0.11.x` but does not yet introduce Python 3.7 support. I'll continue with that in a separate PR.