### PR TITLE
Add `unixodbc` to conda requirements

### DIFF
--- a/docs/pages/contributing.rst
+++ b/docs/pages/contributing.rst
@@ -79,7 +79,7 @@ do the following:
      ::
 
         conda create -y -q -n turbodbc-dev pyarrow numpy pybind11 boost-cpp \
-            pytest pytest-cov mock cmake -c conda-forge
+            pytest pytest-cov mock cmake unixodbc -c conda-forge
         source activate turbodbc-dev
 
 #.  Clone turbodbc into the virtual environment somewhere:


### PR DESCRIPTION
This was missing from the dependencies.