### PR TITLE
Use Xcode 9.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ sudo: required
 matrix:
   include:
   - os: osx
-    osx_image: xcode6.4
+    osx_image: xcode9.4
     language: generic
     env:
     - TRAVIS_PYTHON_VERSION="2.7.12"


### PR DESCRIPTION
6.4 is quite outdated and will be decommissioned soon. Use 9.4 as this is the same base image as conda-forge is using.