### PR TITLE
Support unicode in turbodbc_arrow; Add a conda+Python 3.7 build to the matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,10 +45,14 @@ matrix:
           - unixodbc
           - unixodbc-dev
           - odbc-postgresql
+    services:
+      - docker
+      - postgresql
+      - mysql
     python: "3.7"
     env:
     - TURBODBC_USE_CONDA=yes
-    - TURBODBC_TEST_CONFIGURATION_FILES="query_fixtures_postgresql.json"
+    - TURBODBC_TEST_CONFIGURATION_FILES="query_fixtures_postgresql.json,query_fixtures_mssql.json"
     - ODBC_DIR=odbc
 
 
@@ -113,6 +117,15 @@ install: |
 before_script: |
   if [ "$TRAVIS_OS_NAME" == "linux" ]; then
     $TRAVIS_BUILD_DIR/travis/setup_test_dbs.sh
+    if [ "${TURBODBC_USE_CONDA}" == "yes" ]; then
+      docker run -e 'ACCEPT_EULA=Y' -e 'SA_PASSWORD=StrongPassword1' -p 1433:1433 --name mssql1 -d mcr.microsoft.com/mssql/server:2017-latest
+      sudo bash -c 'curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add -'
+      sudo bash -c 'curl https://packages.microsoft.com/config/ubuntu/16.04/prod.list > /etc/apt/sources.list.d/mssql-release.list'
+      sudo apt-get update
+      sudo ACCEPT_EULA=Y apt-get install msodbcsql17
+      dpkg -L msodbcsql17
+      docker exec -it mssql1 /opt/mssql-tools/bin/sqlcmd -S localhost -U SA -P 'StrongPassword1' -Q 'CREATE DATABASE test_db'
+    fi
   fi
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,20 @@ matrix:
     env:
     - TURBODBC_TEST_CONFIGURATION_FILES="query_fixtures_postgresql.json,query_fixtures_mysql.json"
     - ODBC_DIR=odbc
+  - os: linux
+    dist: xenial
+    language: python
+    addons:
+      apt:
+        packages:
+          - unixodbc
+          - unixodbc-dev
+          - odbc-postgresql
+    python: "3.7"
+    env:
+    - TURBODBC_USE_CONDA=yes
+    - TURBODBC_TEST_CONFIGURATION_FILES="query_fixtures_postgresql.json"
+    - ODBC_DIR=odbc
 
 
 services:
@@ -76,8 +90,25 @@ before_install: |
     psql -U postgres -c "ALTER USER postgres WITH PASSWORD 'password';"
   fi
 
-install:
-  - pip install numpy==1.14.5 pyarrow==0.12.0 six twine pytest-cov coveralls pandas
+  if [ "${TURBODBC_USE_CONDA}" == "yes" ]; then
+    MINICONDA_URL="https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh"
+    wget --no-verbose -O miniconda.sh $MINICONDA_URL
+    export MINICONDA=$HOME/miniconda
+    bash miniconda.sh -b -p $MINICONDA
+    source $MINICONDA/etc/profile.d/conda.sh
+    conda config --remove channels defaults
+    conda config --add channels conda-forge
+    conda create -y -q -n turbodbc-dev pyarrow=0.12.0 numpy pybind11 boost-cpp=1.68 \
+        pytest pytest-cov mock cmake unixodbc coveralls python=3.7 \
+        gxx_linux-64 gcc_linux-64 ninja make \
+        -c conda-forge
+    conda activate turbodbc-dev
+  fi
+
+install: |
+  if [ "${TURBODBC_USE_CONDA}" != "yes" ]; then
+    pip install numpy==1.14.5 pyarrow==0.12.0 six twine pytest-cov coveralls pandas
+  fi
 
 before_script: |
   if [ "$TRAVIS_OS_NAME" == "linux" ]; then
@@ -87,9 +118,15 @@ before_script: |
 script:
   - export ODBCSYSINI=${PWD}/travis/${ODBC_DIR}
   - mkdir build && cd build
-  - cmake -DBUILD_COVERAGE=ON -DCMAKE_INSTALL_PREFIX=./dist -DPYBIND11_PYTHON_VERSION=${TRAVIS_PYTHON_VERSION} ..
-  - make -j4
-  - pip install numpy==1.14.5
+  - |
+    if [ "${TURBODBC_USE_CONDA}" == "yes" ]; then
+      export UNIXODBC_INCLUDE_DIR=$CONDA_PREFIX/include
+      cmake -DBOOST_ROOT=$CONDA_PREFIX -DBUILD_COVERAGE=ON -DCMAKE_INSTALL_PREFIX=./dist  -DPYTHON_EXECUTABLE=`which python` -GNinja ..
+      ninja
+    else
+      cmake -DBUILD_COVERAGE=ON -DCMAKE_INSTALL_PREFIX=./dist -DPYBIND11_PYTHON_VERSION=${TRAVIS_PYTHON_VERSION} ..
+      make -j4
+    fi
   - |
       if [ "$TRAVIS_OS_NAME" == "osx" ]; then
         ctest -E turbodbc_arrow_unit_test --verbose
@@ -112,12 +149,15 @@ script:
   - bash <(curl -s https://codecov.io/bash) -s $PWD/gcov/ -X coveragepy -X gcov
 
   - cd build
-  - make install
+  - cmake --build . --target install
   - cd dist
   - python setup.py sdist
-  - cd dist
-  - pip install *.tar.gz
-  - cd ..
+  - |
+    if [ "${TURBODBC_USE_CONDA}" != "yes" ]; then
+      cd dist
+      pip install *.tar.gz
+      cd ..
+    fi
   - rm -rf dist
 
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,8 @@ Version 3.1.0
 *  Support the unicode datatype in the Arrow support. This primarily enables
    MS SQL support for the Arrow adapter.
 *  Windows support for the Arrow adapter.
+*  Add a new entry to the build matrix that tests Python 3.7 with conda and
+   MS SQL on Linux.
 
 Version 3.0.0
 -------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,9 @@ From version 2.0.0, turbodbc adapts semantic versioning.
 Version 3.1.0
 -------------
 
-*   Update to Apache Arrow 0.12
+*  Update to Apache Arrow 0.12
+*  Support the unicode datatype in the Arrow support. This primarily enables
+   MS SQL support for the Arrow adapter.
 
 Version 3.0.0
 -------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ Version 3.1.0
 *  Update to Apache Arrow 0.12
 *  Support the unicode datatype in the Arrow support. This primarily enables
    MS SQL support for the Arrow adapter.
+*  Windows support for the Arrow adapter.
 
 Version 3.0.0
 -------------

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,11 +18,11 @@ environment:
       PYTHON_VERSION: 3.6
 
     # second group
-    # - PYTHON: C:\Python35-x64
-    #   PYTHON_VERSION: 3.5
+    - PYTHON: C:\Python35-x64
+      PYTHON_VERSION: 3.5
 
-    # - PYTHON: C:\Python37-x64
-    #   PYTHON_VERSION: 3.7
+    - PYTHON: C:\Python37-x64
+      PYTHON_VERSION: 3.7
 
 services:
   - mysql
@@ -57,16 +57,6 @@ build_script:
 
 test_script:
 - cmd: >-
-    choco install dependencywalker -y --allow-empty-checksums
-
-    set PATH=C:/projects/turbodbc_build;C:/Python36-x64/Lib/site-packages/pyarrow;%PATH%
-
-    depends.exe /f:1 /c /oc:c:\projects\turbodbc_build\cpp\turbodbc_arrow\depends.txt C:\projects\turbodbc_build\cpp\turbodbc_arrow\Test\Release\turbodbc_arrow_test.exe
-
-    type c:\projects\turbodbc_build\cpp\turbodbc_arrow\depends.txt
-
-    C:\projects\turbodbc_build\cpp\turbodbc_arrow\Test\Release\turbodbc_arrow_test.exe
-
     reg import ..\turbodbc\appveyor\odbc-mysql.reg
 
     reg import ..\turbodbc\appveyor\odbc-postgresql.reg

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,7 +35,7 @@ install:
 
     SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%
 
-    pip install numpy pytest pytest-cov mock "pyarrow>=0.11,<0.12"
+    pip install numpy pytest pytest-cov mock "pyarrow>=0.11,<0.12" pandas
 
     echo %PYTHON%
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,7 +35,7 @@ install:
 
     SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%
 
-    pip install numpy pytest pytest-cov mock
+    pip install numpy pytest pytest-cov mock "pyarrow>=0.11,<0.12"
 
     echo %PYTHON%
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,11 +18,11 @@ environment:
       PYTHON_VERSION: 3.6
 
     # second group
-    - PYTHON: C:\Python35-x64
-      PYTHON_VERSION: 3.5
+    # - PYTHON: C:\Python35-x64
+    #   PYTHON_VERSION: 3.5
 
-    - PYTHON: C:\Python37-x64
-      PYTHON_VERSION: 3.7
+    # - PYTHON: C:\Python37-x64
+    #   PYTHON_VERSION: 3.7
 
 services:
   - mysql
@@ -57,6 +57,16 @@ build_script:
 
 test_script:
 - cmd: >-
+    choco install dependencywalker -y --allow-empty-checksums
+
+    set PATH=C:/projects/turbodbc_build;C:/Python36-x64/Lib/site-packages/pyarrow;%PATH%
+
+    depends.exe /f:1 /c /oc:c:\projects\turbodbc_build\cpp\turbodbc_arrow\depends.txt C:\projects\turbodbc_build\cpp\turbodbc_arrow\Test\Release\turbodbc_arrow_test.exe
+
+    type c:\projects\turbodbc_build\cpp\turbodbc_arrow\depends.txt
+
+    C:\projects\turbodbc_build\cpp\turbodbc_arrow\Test\Release\turbodbc_arrow_test.exe
+
     reg import ..\turbodbc\appveyor\odbc-mysql.reg
 
     reg import ..\turbodbc\appveyor\odbc-postgresql.reg

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,7 +35,7 @@ install:
 
     SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%
 
-    pip install numpy pytest pytest-cov mock "pyarrow>=0.11,<0.12" pandas
+    pip install numpy pytest pytest-cov mock "pyarrow>=0.12,<0.13" pandas
 
     echo %PYTHON%
 

--- a/cpp/turbodbc_arrow/Library/CMakeLists.txt
+++ b/cpp/turbodbc_arrow/Library/CMakeLists.txt
@@ -1,6 +1,7 @@
 file(GLOB_RECURSE LIBRARY_FILES "src/*.cpp")
 
-pybind11_add_module(turbodbc_arrow_support SHARED ${LIBRARY_FILES})
+# We need to disable LTO on Arrow builds
+pybind11_add_module(turbodbc_arrow_support SHARED ${LIBRARY_FILES} NO_EXTRAS)
 
 set_target_properties(turbodbc_arrow_support PROPERTIES
     PREFIX ""

--- a/cpp/turbodbc_arrow/Library/src/arrow_result_set.cpp
+++ b/cpp/turbodbc_arrow/Library/src/arrow_result_set.cpp
@@ -12,6 +12,7 @@
 #include <turbodbc/time_helpers.h>
 
 #include <ciso646>
+#include <codecvt>
 #include <vector>
 
 using arrow::default_memory_pool;
@@ -105,6 +106,12 @@ std::unique_ptr<ArrayBuilder> make_array_builder(turbodbc::type_code type, bool 
             return std::unique_ptr<TimestampBuilder>(new TimestampBuilder(arrow::timestamp(TimeUnit::MICRO), ::arrow::default_memory_pool()));
         case turbodbc::type_code::date:
             return std::unique_ptr<Date32Builder>(new Date32Builder());
+        case turbodbc::type_code::unicode:
+            if (strings_as_dictionary) {
+                return std::unique_ptr<StringDictionaryBuilder>(new StringDictionaryBuilder(::arrow::utf8(), ::arrow::default_memory_pool()));
+            } else {
+                return std::unique_ptr<StringBuilder>(new StringBuilder());
+            }
         default:
             if (strings_as_dictionary) {
                 return std::unique_ptr<StringDictionaryBuilderProxy>(new StringDictionaryBuilderProxy(::arrow::utf8(), ::arrow::default_memory_pool()));
@@ -122,6 +129,21 @@ Status AppendStringsToBuilder(size_t rows_in_batch, BuilderType& builder, cpp_od
             ARROW_RETURN_NOT_OK(builder.AppendNullProxy());
         } else {
             ARROW_RETURN_NOT_OK(builder.AppendProxy(element.data_pointer, element.indicator));
+        }
+    }
+    return Status::OK();
+}
+
+template <typename BuilderType>
+Status AppendUnicodeStringsToBuilder(size_t rows_in_batch, BuilderType& builder, cpp_odbc::multi_value_buffer const& input_buffer) {
+    for (std::size_t j = 0; j != rows_in_batch; ++j) {
+        auto const element = input_buffer[j];
+        if (element.indicator == SQL_NULL_DATA) {
+            ARROW_RETURN_NOT_OK(builder.AppendNull());
+        } else {
+            std::u16string str_u16(reinterpret_cast<const char16_t*>(element.data_pointer), element.indicator / 2);
+            std::string u8string = std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t>{}.to_bytes(str_u16);;
+            ARROW_RETURN_NOT_OK(builder.Append(u8string));
         }
     }
     return Status::OK();
@@ -227,6 +249,17 @@ Status append_to_string_builder(size_t rows_in_batch, std::unique_ptr<ArrayBuild
 }
 
 
+Status append_to_unicode_builder(size_t rows_in_batch, std::unique_ptr<ArrayBuilder> const& builder, cpp_odbc::multi_value_buffer const& input_buffer, uint8_t*, bool strings_as_dictionary) {
+    if (strings_as_dictionary) {
+        return AppendUnicodeStringsToBuilder<StringDictionaryBuilder>(rows_in_batch,
+            static_cast<StringDictionaryBuilder&>(*builder), input_buffer);
+    }
+
+    return AppendUnicodeStringsToBuilder<StringBuilder>(rows_in_batch,
+        static_cast<StringBuilder&>(*builder), input_buffer);
+}
+
+
 Status arrow_result_set::process_batch(size_t rows_in_batch, std::vector<std::unique_ptr<ArrayBuilder>> const& columns) {
     // TODO: Use a PoolBuffer for this and only allocate it once
     auto const column_info = base_result_.get_column_info();
@@ -258,6 +291,9 @@ Status arrow_result_set::process_batch(size_t rows_in_batch, std::vector<std::un
                 break;
             case turbodbc::type_code::date:
                 ARROW_RETURN_NOT_OK(append_to_date_builder(rows_in_batch, columns[i], buffers[i].get(), valid_bytes.data()));
+                break;
+            case turbodbc::type_code::unicode:
+                ARROW_RETURN_NOT_OK(append_to_unicode_builder(rows_in_batch, columns[i], buffers[i].get(), valid_bytes.data(), strings_as_dictionary_));
                 break;
             default:
                 // Strings are the only remaining type

--- a/cpp/turbodbc_arrow/Library/src/arrow_result_set.cpp
+++ b/cpp/turbodbc_arrow/Library/src/arrow_result_set.cpp
@@ -140,11 +140,11 @@ Status AppendUnicodeStringsToBuilder(size_t rows_in_batch, BuilderType& builder,
     for (std::size_t j = 0; j != rows_in_batch; ++j) {
         auto const element = input_buffer[j];
         if (element.indicator == SQL_NULL_DATA) {
-            ARROW_RETURN_NOT_OK(builder.AppendNull());
+            ARROW_RETURN_NOT_OK(builder.AppendNullProxy());
         } else {
             std::u16string str_u16(reinterpret_cast<const char16_t*>(element.data_pointer), element.indicator / 2);
             std::string u8string = boost::locale::conv::utf_to_utf<char>(str_u16);;
-            ARROW_RETURN_NOT_OK(builder.Append(u8string));
+            ARROW_RETURN_NOT_OK(builder.AppendProxy(u8string.data(), u8string.size()));
         }
     }
     return Status::OK();

--- a/cpp/turbodbc_arrow/Library/src/arrow_result_set.cpp
+++ b/cpp/turbodbc_arrow/Library/src/arrow_result_set.cpp
@@ -109,9 +109,9 @@ std::unique_ptr<ArrayBuilder> make_array_builder(turbodbc::type_code type, bool 
             return std::unique_ptr<Date32Builder>(new Date32Builder());
         case turbodbc::type_code::unicode:
             if (strings_as_dictionary) {
-                return std::unique_ptr<StringDictionaryBuilder>(new StringDictionaryBuilder(::arrow::utf8(), ::arrow::default_memory_pool()));
+                return std::unique_ptr<StringDictionaryBuilderProxy>(new StringDictionaryBuilderProxy(::arrow::utf8(), ::arrow::default_memory_pool()));
             } else {
-                return std::unique_ptr<StringBuilder>(new StringBuilder());
+                return std::unique_ptr<StringBuilderProxy>(new StringBuilderProxy());
             }
         default:
             if (strings_as_dictionary) {
@@ -252,12 +252,12 @@ Status append_to_string_builder(size_t rows_in_batch, std::unique_ptr<ArrayBuild
 
 Status append_to_unicode_builder(size_t rows_in_batch, std::unique_ptr<ArrayBuilder> const& builder, cpp_odbc::multi_value_buffer const& input_buffer, uint8_t*, bool strings_as_dictionary) {
     if (strings_as_dictionary) {
-        return AppendUnicodeStringsToBuilder<StringDictionaryBuilder>(rows_in_batch,
-            static_cast<StringDictionaryBuilder&>(*builder), input_buffer);
+        return AppendUnicodeStringsToBuilder<StringDictionaryBuilderProxy>(rows_in_batch,
+            static_cast<StringDictionaryBuilderProxy&>(*builder), input_buffer);
     }
 
-    return AppendUnicodeStringsToBuilder<StringBuilder>(rows_in_batch,
-        static_cast<StringBuilder&>(*builder), input_buffer);
+    return AppendUnicodeStringsToBuilder<StringBuilderProxy>(rows_in_batch,
+        static_cast<StringBuilderProxy&>(*builder), input_buffer);
 }
 
 

--- a/cpp/turbodbc_arrow/Library/src/arrow_result_set.cpp
+++ b/cpp/turbodbc_arrow/Library/src/arrow_result_set.cpp
@@ -12,8 +12,9 @@
 #include <turbodbc/time_helpers.h>
 
 #include <ciso646>
-#include <codecvt>
 #include <vector>
+
+#include <boost/locale.hpp>
 
 using arrow::default_memory_pool;
 using arrow::AdaptiveIntBuilder;
@@ -142,7 +143,7 @@ Status AppendUnicodeStringsToBuilder(size_t rows_in_batch, BuilderType& builder,
             ARROW_RETURN_NOT_OK(builder.AppendNull());
         } else {
             std::u16string str_u16(reinterpret_cast<const char16_t*>(element.data_pointer), element.indicator / 2);
-            std::string u8string = std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t>{}.to_bytes(str_u16);;
+            std::string u8string = boost::locale::conv::utf_to_utf<char>(str_u16);;
             ARROW_RETURN_NOT_OK(builder.Append(u8string));
         }
     }

--- a/cpp/turbodbc_arrow/Library/src/set_arrow_parameters.cpp
+++ b/cpp/turbodbc_arrow/Library/src/set_arrow_parameters.cpp
@@ -12,7 +12,8 @@
 #include <sql.h>
 
 #include <ciso646>
-#include <codecvt>
+
+#include <boost/locale.hpp>
 
 using arrow::BooleanArray;
 using arrow::BinaryArray;
@@ -138,7 +139,7 @@ namespace {
         size_t maximum_length = 0;
         for (int64_t i = 0; i != elements; ++i) {
           if (!typed_array.IsNull(start + i)) {
-            std::u16string str = std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t>{}.from_bytes(typed_array.GetString(start + i));
+            std::u16string str = boost::locale::conv::utf_to_utf<char16_t>(typed_array.GetString(start + i));
             maximum_length = std::max(maximum_length, str.length());
             batch.push_back({false, str});
           } else {

--- a/cpp/turbodbc_arrow/Test/CMakeLists.txt
+++ b/cpp/turbodbc_arrow/Test/CMakeLists.txt
@@ -36,6 +36,10 @@ if (UNIX)
     target_link_libraries(turbodbc_arrow_test
         pthread
     )
+    # VERSION_GREATER_EQUAL and target_link_options are only supported in newer CMake versions
+    if (NOT (${CMAKE_VERSION} VERSION_LESS "3.13"))
+        target_link_options(turbodbc_arrow_test PUBLIC "-pthread")
+    endif()
 endif()
 
 add_test(NAME turbodbc_arrow_unit_test

--- a/cpp/turbodbc_arrow/Test/CMakeLists.txt
+++ b/cpp/turbodbc_arrow/Test/CMakeLists.txt
@@ -25,6 +25,13 @@ target_link_libraries(turbodbc_arrow_test
     gmock
 )
 
+if (MSVC)
+    target_link_libraries(turbodbc_arrow_test
+        ${ARROW_SHARED_IMP_LIB}
+        ${ARROW_PYTHON_SHARED_IMP_LIB}
+    )
+endif()
+
 if (UNIX)
     target_link_libraries(turbodbc_arrow_test
         pthread
@@ -36,9 +43,10 @@ add_test(NAME turbodbc_arrow_unit_test
 
 if (WIN32)
     get_filename_component(ARROW_LIBS "${ARROW_SHARED_LIB}" DIRECTORY)
+    string(REPLACE ";" "\\;" MASKED_PATH "$ENV{PATH}")
     set_tests_properties(
         turbodbc_arrow_unit_test
         PROPERTIES
-        ENVIRONMENT "PATH=${CMAKE_BINARY_DIR};$ENV{PATH};${ARROW_LIBS}"
+        ENVIRONMENT "PATH=${CMAKE_BINARY_DIR}\;${ARROW_LIBS}\;${MASKED_PATH}"
     )
 endif()

--- a/cpp/turbodbc_arrow/Test/CMakeLists.txt
+++ b/cpp/turbodbc_arrow/Test/CMakeLists.txt
@@ -38,6 +38,6 @@ if (WIN32)
     set_tests_properties(
         turbodbc_arrow_unit_test
         PROPERTIES
-        ENVIRONMENT "PATH=${CMAKE_BINARY_DIR};$ENV{PATH}"
+        ENVIRONMENT "PATH=${CMAKE_BINARY_DIR};$ENV{PATH};${ARROW_LIB_PATH}"
     )
 endif()

--- a/cpp/turbodbc_arrow/Test/CMakeLists.txt
+++ b/cpp/turbodbc_arrow/Test/CMakeLists.txt
@@ -35,9 +35,10 @@ add_test(NAME turbodbc_arrow_unit_test
          COMMAND turbodbc_arrow_test --gtest_output=xml:${CMAKE_BINARY_DIR}/turbodbc_arrow_test.xml)
 
 if (WIN32)
+    get_filename_component(ARROW_LIBS "${ARROW_SHARED_LIB}" DIRECTORY)
     set_tests_properties(
         turbodbc_arrow_unit_test
         PROPERTIES
-        ENVIRONMENT "PATH=${CMAKE_BINARY_DIR};$ENV{PATH};${ARROW_LIB_PATH}"
+        ENVIRONMENT "PATH=${CMAKE_BINARY_DIR};$ENV{PATH};${ARROW_LIBS}"
     )
 endif()

--- a/cpp/turbodbc_arrow/Test/tests/arrow_result_set_test.cpp
+++ b/cpp/turbodbc_arrow/Test/tests/arrow_result_set_test.cpp
@@ -3,6 +3,7 @@
 #include <list>
 
 #undef BOOL
+#undef timezone
 #include <arrow/api.h>
 #include <arrow/test-util.h>
 #include <gtest/gtest.h>

--- a/python/turbodbc_test/test_select_arrow.py
+++ b/python/turbodbc_test/test_select_arrow.py
@@ -174,14 +174,14 @@ def test_arrow_timestamp_column(dsn, configuration):
 @for_each_database
 @pyarrow
 def test_arrow_date_column(dsn, configuration):
-    date = datetime.date(3999, 12, 31)
+    date = datetime.date(2015, 12, 31)
 
     with open_cursor(configuration) as cursor:
         with query_fixture(cursor, configuration, 'INSERT DATE') as table_name:
             cursor.execute('INSERT INTO {} VALUES (?)'.format(table_name), [date])
             cursor.execute('SELECT a FROM {}'.format(table_name))
             result = cursor.fetchallarrow()
-            result.column(0).to_pylist() == [datetime.date(3999, 12, 31)]
+            result.column(0).to_pylist() == [datetime.date(2015, 12, 31)]
 
 
 @for_each_database

--- a/python/turbodbc_test/test_select_arrow.py
+++ b/python/turbodbc_test/test_select_arrow.py
@@ -220,7 +220,7 @@ def test_arrow_timelike_column_larger_than_batch_size(dsn, configuration):
 @pytest.mark.parametrize("strings_as_dictionary", [True, False])
 def test_arrow_string_column(dsn, configuration, strings_as_dictionary):
     with open_cursor(configuration) as cursor:
-        with query_fixture(cursor, configuration, 'INSERT STRING') as table_name:
+        with query_fixture(cursor, configuration, 'INSERT UNICODE') as table_name:
             cursor.execute('INSERT INTO {} VALUES (?)'.format(table_name), [u'unicode \u2665'])
             cursor.execute('SELECT a FROM {}'.format(table_name))
             result = cursor.fetchallarrow(strings_as_dictionary=strings_as_dictionary)

--- a/travis/odbc/odbc.ini
+++ b/travis/odbc/odbc.ini
@@ -19,3 +19,9 @@ UseServerSidePrepare = 1
 BoolsAsChar          = 0
 ConnSettings         = set time zone 'UTC';
 UseDeclareFetch      = 1
+
+[MSSQL]
+Driver = ODBC Driver 17 for SQL Server
+Server = localhost
+Port = 1433
+Database = test_db

--- a/travis/odbc/odbcinst.ini
+++ b/travis/odbc/odbcinst.ini
@@ -7,3 +7,7 @@ Threading   = 2
 Driver      = /usr/lib/x86_64-linux-gnu/odbc/psqlodbcw.so
 FileUsage   = 1
 Threading   = 2
+
+[ODBC Driver 17 for SQL Server]
+Description=Microsoft ODBC Driver 17 for SQL Server
+Driver=/opt/microsoft/msodbcsql17/lib64/libmsodbcsql-17.2.so.0.1


### PR DESCRIPTION
This is a combination of 2 PRs with an additional commit to test MS SQL on Linux to get to a green coverage for the Arrow changes.

Fixes #194
Fixes #190
Fixes #128
Fixes #166
Fixes #165