### PR TITLE
Arrow 0.13.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ matrix:
     - TRAVIS_PYTHON_VERSION="2.7.12"
     - TURBODBC_TEST_CONFIGURATION_FILES="query_fixtures_postgresql.json"
     - ODBC_DIR=odbc_osx
+    - TURBODBC_ARROW_VERSION=0.13.0
 #  Disable for now until a workaround for the detection of pyenv versions by pybind11
 #  is found
 #  - os: osx
@@ -24,18 +25,28 @@ matrix:
     env:
     - TURBODBC_TEST_CONFIGURATION_FILES="query_fixtures_postgresql.json,query_fixtures_mysql.json"
     - ODBC_DIR=odbc
+    - TURBODBC_ARROW_VERSION=0.13.0
   - os: linux
     language: python
     python: "3.5"
     env:
     - TURBODBC_TEST_CONFIGURATION_FILES="query_fixtures_postgresql.json,query_fixtures_mysql.json"
     - ODBC_DIR=odbc
+    - TURBODBC_ARROW_VERSION=0.13.0
   - os: linux
     language: python
     python: "3.6"
     env:
     - TURBODBC_TEST_CONFIGURATION_FILES="query_fixtures_postgresql.json,query_fixtures_mysql.json"
     - ODBC_DIR=odbc
+    - TURBODBC_ARROW_VERSION=0.12.1
+  - os: linux
+    language: python
+    python: "3.6"
+    env:
+    - TURBODBC_TEST_CONFIGURATION_FILES="query_fixtures_postgresql.json,query_fixtures_mysql.json"
+    - ODBC_DIR=odbc
+    - TURBODBC_ARROW_VERSION=0.13.0
   - os: linux
     dist: xenial
     language: python
@@ -54,6 +65,7 @@ matrix:
     - TURBODBC_USE_CONDA=yes
     - TURBODBC_TEST_CONFIGURATION_FILES="query_fixtures_postgresql.json,query_fixtures_mssql.json"
     - ODBC_DIR=odbc
+    - TURBODBC_ARROW_VERSION=0.13.0
 
 
 services:
@@ -102,7 +114,7 @@ before_install: |
     source $MINICONDA/etc/profile.d/conda.sh
     conda config --remove channels defaults
     conda config --add channels conda-forge
-    conda create -y -q -n turbodbc-dev pyarrow=0.12.0 numpy pybind11 boost-cpp=1.68 \
+    conda create -y -q -n turbodbc-dev pyarrow=$TURBODBC_ARROW_VERSION numpy pybind11 boost-cpp=1.68 \
         pytest pytest-cov mock cmake unixodbc coveralls gtest gmock python=3.7 \
         gxx_linux-64 gcc_linux-64 ninja make \
         -c conda-forge
@@ -111,7 +123,7 @@ before_install: |
 
 install: |
   if [ "${TURBODBC_USE_CONDA}" != "yes" ]; then
-    pip install numpy==1.14.5 pyarrow==0.12.0 six twine pytest-cov coveralls pandas
+    pip install numpy==1.14.5 pyarrow==$TURBODBC_ARROW_VERSION six twine pytest-cov coveralls pandas
   fi
 
 before_script: |

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ sudo: required
 matrix:
   include:
   - os: osx
+    name: CPython2.7 Arrow 0.13.0
     osx_image: xcode9.4
     language: generic
     env:
@@ -20,6 +21,7 @@ matrix:
 #    - TURBODBC_TEST_CONFIGURATION_FILES="query_fixtures_postgresql.json"
 #    - ODBC_DIR=odbc_osx
   - os: linux
+    name: CPython2.7 Arrow 0.13.0
     language: python
     python: "2.7"
     env:
@@ -27,6 +29,7 @@ matrix:
     - ODBC_DIR=odbc
     - TURBODBC_ARROW_VERSION=0.13.0
   - os: linux
+    name: CPython3.5 Arrow 0.13.0
     language: python
     python: "3.5"
     env:
@@ -34,6 +37,7 @@ matrix:
     - ODBC_DIR=odbc
     - TURBODBC_ARROW_VERSION=0.13.0
   - os: linux
+    name: CPython3.6 Arrow 0.12.1
     language: python
     python: "3.6"
     env:
@@ -41,6 +45,7 @@ matrix:
     - ODBC_DIR=odbc
     - TURBODBC_ARROW_VERSION=0.12.1
   - os: linux
+    name: CPython3.6 Arrow 0.13.0
     language: python
     python: "3.6"
     env:
@@ -48,6 +53,7 @@ matrix:
     - ODBC_DIR=odbc
     - TURBODBC_ARROW_VERSION=0.13.0
   - os: linux
+    name: CPython3.7 Arrow 0.13.0
     dist: xenial
     language: python
     addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,6 +79,11 @@ services:
   - postgresql
 
 addons:
+  homebrew:
+    packages:
+      - unixodbc
+      - pyenv-virtualenv
+      - psqlodbc
   apt:
     packages:
       - unixodbc
@@ -91,11 +96,6 @@ addons:
 
 before_install: |
   if [ "$TRAVIS_OS_NAME" == "osx" ]; then
-    brew update
-    brew outdated pyenv || brew upgrade pyenv
-    brew install unixodbc
-    brew install pyenv-virtualenv
-    brew install psqlodbc
     eval "$(pyenv init -)"
     pyenv install ${TRAVIS_PYTHON_VERSION}
     pyenv virtualenv ${TRAVIS_PYTHON_VERSION} turbodbc
@@ -120,16 +120,38 @@ before_install: |
     source $MINICONDA/etc/profile.d/conda.sh
     conda config --remove channels defaults
     conda config --add channels conda-forge
-    conda create -y -q -n turbodbc-dev pyarrow=$TURBODBC_ARROW_VERSION numpy pybind11 boost-cpp=1.68 \
-        pytest pytest-cov mock cmake unixodbc coveralls gtest gmock python=3.7 \
-        gxx_linux-64 gcc_linux-64 ninja make \
+    conda create -y -q -n turbodbc-dev \
+        gcc_linux-64 \
+        make \
+        ninja \
+        cmake \
+        coveralls \
+        gmock \
+        gtest \
+        gxx_linux-64 \
+        mock \
+        pytest \
+        pytest-cov \
+        python=3.7 \
+        unixodbc \
+        boost-cpp=1.68 \
+        numpy \
+        pyarrow=$TURBODBC_ARROW_VERSION \
+        pybind11 \
         -c conda-forge
     conda activate turbodbc-dev
   fi
 
 install: |
   if [ "${TURBODBC_USE_CONDA}" != "yes" ]; then
-    pip install numpy==1.14.5 pyarrow==$TURBODBC_ARROW_VERSION six twine pytest-cov coveralls pandas
+    pip install \
+      coveralls \
+      numpy==1.14.5 \
+      pandas \
+      pyarrow==$TURBODBC_ARROW_VERSION \
+      pytest-cov \
+      six \
+      twine 
   fi
 
 before_script: |

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ Version 3.1.1
   (thanks @byjott)
 * Support user-provided gmock/gtest, e.g. in conda environments via
   ``conda install -c conda-forge gtest gmock``.
+* Make source code compatible with Apache Arrow 0.13.0
 
 Version 3.1.0
 -------------

--- a/setup.py
+++ b/setup.py
@@ -216,7 +216,7 @@ setup(name = 'turbodbc',
       packages = ['turbodbc'],
       extras_require={
           # We pin Apache Arrow quite restrictively until they guarantee a stable API
-          'arrow': ['pyarrow>=0.12,<0.13'],
+          'arrow': ['pyarrow>=0.12,<0.14'],
           'numpy': 'numpy>=1.14.0'
       },
       classifiers = ['Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
API seems to be still compatible. I extended the version in setup.cfg and extended the travis build matrix to reflect that.

The only change required to the code base was to remove arrow/test-utils.h form the arrow compatibility tests since that header no longer exists. `turbodbc` only used two small macros which I added to the test file itself