### PR TITLE
Follow Apache Arrow API changes for variable dictionaries coming in 0.14.x

### DIFF
--- a/cpp/turbodbc_arrow/Library/src/arrow_result_set.cpp
+++ b/cpp/turbodbc_arrow/Library/src/arrow_result_set.cpp
@@ -71,14 +71,14 @@ class StringDictionaryBuilderProxy: public StringDictionaryBuilder {
         // ARROW-4367: StringDictionaryBuilder segfaults on Finish with only null entries
         if (length_ == null_count_) {
             auto values = std::make_shared<arrow::StringArray>(0, std::shared_ptr<arrow::Buffer>(), std::shared_ptr<arrow::Buffer>());
-            auto type = arrow::dictionary(arrow::int32(), values);
+            auto type = arrow::dictionary(arrow::int32(), arrow::utf8());
             Int32Builder builder;
             for (size_t i = 0; i != length_; i++) {
                 ARROW_RETURN_NOT_OK(builder.AppendNull());
             }
             std::shared_ptr<arrow::Array> indices;
             ARROW_RETURN_NOT_OK(builder.Finish(&indices));
-            *out = arrow::DictionaryArray(type, indices).data();
+            *out = arrow::DictionaryArray(type, indices, values).data();
 
             return Status::OK();
         }


### PR DESCRIPTION
As a result of ARROW-3144 the dictionary values are now a member of the Array object rather than the Type object, so that the values can vary from array to array while still having semantically the same type, e.g. "dictionary-encoded string".

I don't think this should impact turbodbc too much but if you can assist with more exhaustive testing I will be happy to help sort out any issues that come up.