### PR TITLE
Arrow: release GIL when fetching batch

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,12 @@ Version history / changelog
 
 From version 2.0.0, turbodbc adapts semantic versioning.
 
+Next release
+------------
+
+* Release GIL while fetching batches using Apache Arrow engine
+
+
 Version 3.1.1
 -------------
 

--- a/cpp/turbodbc_arrow/Library/src/arrow_result_set.cpp
+++ b/cpp/turbodbc_arrow/Library/src/arrow_result_set.cpp
@@ -360,8 +360,11 @@ Status arrow_result_set::fetch_all_native(std::shared_ptr<arrow::Table>* out, bo
 pybind11::object arrow_result_set::fetch_next_batch()
 {
     std::shared_ptr<arrow::Table> table;
-    if (not fetch_all_native(&table, true).ok()) {
-        throw turbodbc::interface_error("Fetching Arrow result set failed.");
+    {
+        pybind11::gil_scoped_release release;
+        if (not fetch_all_native(&table, true).ok()) {
+            throw turbodbc::interface_error("Fetching Arrow result set failed.");
+        }
     }
 
     arrow::py::import_pyarrow();
@@ -372,10 +375,12 @@ pybind11::object arrow_result_set::fetch_next_batch()
 pybind11::object arrow_result_set::fetch_all()
 {
     std::shared_ptr<arrow::Table> table;
-    if (not fetch_all_native(&table, false).ok()) {
-        throw turbodbc::interface_error("Fetching Arrow result set failed.");
+    {
+        pybind11::gil_scoped_release release;
+        if (not fetch_all_native(&table, false).ok()) {
+            throw turbodbc::interface_error("Fetching Arrow result set failed.");
+        }
     }
-
     arrow::py::import_pyarrow();
     return pybind11::reinterpret_steal<pybind11::object>(pybind11::handle(arrow::py::wrap_table(table)));
 }


### PR DESCRIPTION
We're observing issues when using turbodbc within dark.distributed and get messages about long holding GILs.

Browsing the code I noticed that we release the GIL in the numpy backend when fetching the batches. I don't know turbodbc well but I'm wondering if we shouldn't do the same for the arrow backend, c.f. https://github.com/blue-yonder/turbodbc/blob/85927590843607406aa9d54c5ae0f1dc3d6b31f5/cpp/turbodbc_numpy/Library/src/numpy_result_set.cpp#L55