### PR TITLE
Typos in the docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ matrix:
     osx_image: xcode9.4
     language: generic
     env:
-    - TRAVIS_PYTHON_VERSION="2.7.12"
+    - TRAVIS_PYTHON_VERSION="2.7.13"
     - TURBODBC_TEST_CONFIGURATION_FILES="query_fixtures_postgresql.json"
     - ODBC_DIR=odbc_osx
     - TURBODBC_ARROW_VERSION=0.13.0
@@ -220,6 +220,7 @@ before_script: |
       sudo apt-get update
       sudo ACCEPT_EULA=Y apt-get install msodbcsql17
       dpkg -L msodbcsql17
+      docker exec -it mssql1 /opt/mssql-tools/bin/sqlcmd -S localhost -U SA -P 'StrongPassword1' -Q 'SELECT @@VERSION' || sleep 10
       docker exec -it mssql1 /opt/mssql-tools/bin/sqlcmd -S localhost -U SA -P 'StrongPassword1' -Q 'CREATE DATABASE test_db'
     fi
   fi

--- a/docs/pages/advanced_usage.rst
+++ b/docs/pages/advanced_usage.rst
@@ -103,7 +103,7 @@ Prefer unicode
 Set ``prefer_unicode`` to ``True`` if your database does not fully support
 the UTF-8 encoding turbodbc prefers. With this option you can tell turbodbc
 to use two-byte character strings with UCS-2/UTF-16 encoding. Use this option
-if you try to connection to Microsoft SQL server (MSSQL).
+if you wish to connect to Microsoft SQL Server (MSSQL).
 
 
 .. _advanced_usage_options_autocommit:
@@ -127,7 +127,7 @@ Large decimals as 64 bit types
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Set ``large_decimals_as_64_bit_types`` to ``True`` if you want to retrieve
-``Decimal`` and ``Numeric`` types with more than ``18`` digits as the 64 bit
+``Decimal`` and ``Numeric`` types with more than ``18`` digits as 64 bit
 ``integer`` and ``float`` numbers. The default is to retrieve such fields
 as strings instead.
 
@@ -258,7 +258,7 @@ Notes regarding NumPy result sets
     order is the same as in your query.
 *   The column values are of type ``MaskedArray``. Any ``NULL`` values you have in your
     database will show up as masked entries (``NULL`` values in string-like columns
-    will shop up as ``None`` objects).
+    will show up as ``None`` objects).
 
 The following table shows how the most common data types data scientists are interested in
 are converted to NumPy columns:
@@ -276,9 +276,9 @@ are converted to NumPy columns:
 +-----------------------------------+------------------------------+
 | ``BIT``, boolean-like             | ``bool_``                    |
 +-----------------------------------+------------------------------+
-| ``TIMESTAMP``, ``TIME``           | ``datetime64[us]``           |
+| ``TIMESTAMP``, ``TIME``           | ``datetime64[µs]``           |
 +-----------------------------------+------------------------------+
-| ``DATE``                          | ``datetime64[D}``            |
+| ``DATE``                          | ``datetime64[D]``            |
 +-----------------------------------+------------------------------+
 | ``VARCHAR``, strings              | ``object_``                  |
 +-----------------------------------+------------------------------+
@@ -318,9 +318,9 @@ as query parameters with ``executemanycolumns()``:
 *   Each column must contain one-dimensional, contiguous data.
 *   All columns must have equal size.
 *   The ``dtype`` of each column must be supported, see the table below.
-*   Use ``MaskedArray``s with and set the ``mask`` to ``True`` for individual
+*   Use ``MaskedArray`` and set the ``mask`` to ``True`` for individual
     elements to use ``None`` values.
-*   Data is transfered in batches (see :ref:`advanced_usage_options_write_buffer`)
+*   Data is transferred in batches (see :ref:`advanced_usage_options_write_buffer`)
 
 
 +-------------------------------------------------------------------------+--------------------------------+
@@ -332,7 +332,7 @@ as query parameters with ``executemanycolumns()``:
 +-------------------------------------------------------------------------+--------------------------------+
 | ``bool_``                                                               | ``BIT``                        |
 +-------------------------------------------------------------------------+--------------------------------+
-| ``datetime64[us]``                                                      | ``TIMESTAMP``                  |
+| ``datetime64[µs]``                                                      | ``TIMESTAMP``                  |
 +-------------------------------------------------------------------------+--------------------------------+
 | ``datetime64[ns]``                                                      | ``TIMESTAMP``                  |
 +-------------------------------------------------------------------------+--------------------------------+
@@ -397,7 +397,7 @@ As a performance optimisation for string columns, you can specify the parameter
 ``strings_as_dictionary``. This will retrieve all string columns as Arrow
 ``DictionaryArray``. The data will here be split into two arrays, one that stores
 all unique string values and one integer array that stores for each row the index
-in the dictionary. On converions to Pandas, these columns will be turned into
+in the dictionary. On conversion to Pandas, these columns will be turned into
 ``pandas.Categorical``.
 
 ::
@@ -474,8 +474,8 @@ returned by the database. This mode can be activated by setting
 Obtaining Apache Arrow result sets in batches
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Similar to the numpy support for fetching results as batche, you can
-fetch an query result as an iterator of pyarrow tables.
+Similar to the numpy support for fetching results as a batch, you can
+fetch a query result as an iterator of pyarrow tables.
 
 ::
 
@@ -523,19 +523,19 @@ tables as query parameters with ``executemanycolumns()``:
     no support for chunked arrays yet.
 *   All columns must have equal size.
 *   The ``dtype`` of each column must be supported, see the table below.
-*   Data is transfered in batches (see :ref:`advanced_usage_options_write_buffer`)
+*   Data is transferred in batches (see :ref:`advanced_usage_options_write_buffer`)
 
 
 +------------------------------------------------------------------------------+--------------------------------+
 | Supported Apache Arrow type                                                  | Transferred as                 |
 +==============================================================================+================================+
 | ``INT8``, ``UINT8``, ``INT16``, ``UINT16``, ``INT32``, ``UINT32``, ``INT64`` | ``BIGINT`` (64 bits)           |
-+-------------------------------------------------------------------------+-------------------------------------+
++------------------------------------------------------------------------------+--------------------------------+
 | ``DOUBLE``                                                                   | ``DOUBLE PRECISION`` (64 bits) |
 +------------------------------------------------------------------------------+--------------------------------+
 | ``BOOL``                                                                     | ``BIT``                        |
 +------------------------------------------------------------------------------+--------------------------------+
-| ``TIMESTAMP[us]``                                                            | ``TIMESTAMP``                  |
+| ``TIMESTAMP[µs]``                                                            | ``TIMESTAMP``                  |
 +------------------------------------------------------------------------------+--------------------------------+
 | ``TIMESTAMP[ns]``                                                            | ``TIMESTAMP``                  |
 +------------------------------------------------------------------------------+--------------------------------+

--- a/docs/pages/contributing.rst
+++ b/docs/pages/contributing.rst
@@ -156,4 +156,4 @@ do the following:
     by others to install turbodbc with ``pip install turbodbc-x.y.z.tar.gz``.
 
 
-.. _GitHub: <https://github.com/blue-yonder/turbodbc>
+.. _GitHub: https://github.com/blue-yonder/turbodbc

--- a/docs/pages/contributing.rst
+++ b/docs/pages/contributing.rst
@@ -57,13 +57,12 @@ do the following:
 
 #.  Create development environment depending on your Python package manager.
 
-    - For a pip-based workflow, a virtual environment, activate it, and install
+    - For a pip-based workflow, create a virtual environment, activate it, and install
       the necessary packages numpy, pyarrow, pytest, and mock:
 
       ::
 
-           pip install numpy pytest pytest-cov mock pyarrow
-
+            pip install numpy pytest pytest-cov mock pyarrow
 
       Make sure you have a recent version of ``cmake`` installed. For some operating
       systems, binary wheels are available in addition to the package your operating
@@ -71,12 +70,12 @@ do the following:
 
       ::
 
-          pip install cmake
+            pip install cmake
 
-   - If you're using ``conda`` to manage your python packages, you can install the
-     dependencies from conda-forge:
+    - If you're using ``conda`` to manage your python packages, you can install the
+      dependencies from conda-forge:
 
-     ::
+      ::
 
         conda create -y -q -n turbodbc-dev pyarrow numpy pybind11 boost-cpp \
             pytest pytest-cov mock cmake unixodbc gtest gmock -c conda-forge

--- a/docs/pages/databases/mssql.rst
+++ b/docs/pages/databases/mssql.rst
@@ -1,7 +1,7 @@
-Microsoft SQL server (MSSQL)
+Microsoft SQL Server (MSSQL)
 ============================
 
-`Microsoft SQL server <https://www.microsoft.com/sql>`_ (MSSQL) is part of turbodbc's
+`Microsoft SQL Server <https://www.microsoft.com/sql>`_ (MSSQL) is part of turbodbc's
 integration databases. That means that each commit in turbodbc's repository
 is automatically tested against MSSQL to ensure compatibility.
 Here are the recommended settings for connecting to a Microsoft SQL database via ODBC

--- a/docs/pages/databases/mssql.rst
+++ b/docs/pages/databases/mssql.rst
@@ -59,13 +59,13 @@ Official Microsoft ODBC driver (Windows)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Put these values in your registry under the given key. Be sure to prefer the
-`latest ODBC driver <https://www.microsoft.com/en-us/download/details.aspx?id=50420>`_
+`latest ODBC driver <https://www.microsoft.com/en-us/download/details.aspx?id=56567>`_
 over any driver that may come bundled with your Windows version.
 
 .. code-block:: ini
 
     [HKEY_LOCAL_MACHINE\SOFTWARE\ODBC\ODBC.INI\MSSQL]
-    "Driver"="C:\\Windows\\system32\\msodbcsql13.dll"
+    "Driver"="C:\\Windows\\system32\\msodbcsql17.dll"
     "Server"="<host>"
     "Database"="<database>"
 

--- a/docs/pages/faq.rst
+++ b/docs/pages/faq.rst
@@ -36,9 +36,9 @@ Is there a guided tour through turbodbc's entrails?
 
 Yes, there is! Check out these blog posts on the making of turbodbc:
 
-*   Part one: `Wrestling with the side effects of a C API <http://tech.blue-yonder.com/making-of-turbodbc-part-1-wrestling-with-the-side-effects-of-a-c-api/>`_.
+*   Part one: `Wrestling with the side effects of a C API <https://tech.jda.com/making-of-turbodbc-part-1-wrestling-with-the-side-effects-of-a-c-api/>`_.
     This explains the C++ layer that is used to handle all calls to the ODBC API.
-*   Part two: `C++ to Python <https://tech.blue-yonder.com/making-of-turbodbc-part-2-c-to-python/>`_
+*   Part two: `C++ to Python <https://tech.jda.com/making-of-turbodbc-part-2-c-to-python/>`_
     This explains how concepts of the ODBC API are transformed into an API compliant
     with Python's database API, including making use of `pybind11 <https://github.com/pybind/pybind11>`_.
 
@@ -63,4 +63,4 @@ There are a few options:
     for new releases.
 
 
-.. _GitHub: <https://github.com/blue-yonder/turbodbc>
+.. _GitHub: https://github.com/blue-yonder/turbodbc

--- a/docs/pages/faq.rst
+++ b/docs/pages/faq.rst
@@ -13,7 +13,7 @@ Using Turbodbc in combination with SQLAlchemy is possible for a (currently) limi
 All of the above packages are available on PyPI. There are also more experimental implementations
 available:
 
-*   `Vertica <https://www.vertica.com>`_: Inofficial
+*   `Vertica <https://www.vertica.com>`_: Unofficial
     `fork of sqlalchemy-vertica <https://github.com/startappdev/sqlalchemy-vertica>`_
 
 Where would I report issues concerning turbodbc?
@@ -26,7 +26,7 @@ Where can I ask questions regarding turbodbc?
 ---------------------------------------------
 
 Basically, you can ask them anywhere, chances to get a helpful answer may vary, though.
-I suggest to ask questions either using turbodbc's issue tracker on
+I suggest asking questions either using turbodbc's issue tracker on
 `GitHub`_ or by heading over to
 `stackoverflow <http://stackoverflow.com/search?q=turbodbc>`_.
 

--- a/docs/pages/getting_started.rst
+++ b/docs/pages/getting_started.rst
@@ -186,7 +186,7 @@ You can now execute a basic ``INSERT`` query:
     >>> cursor.execute("INSERT INTO TABLE my_integer_table VALUES (42, 17)")
 
 This will insert two values, ``42`` and ``17``, in a single row of table ``my_integer_table``.
-Inserting values like this is impractical, because it requires to put the values
+Inserting values like this is impractical, because it requires putting the values
 into the actual SQL string.
 
 To avoid this, you can pass parameters to ``execute()``:
@@ -198,7 +198,7 @@ To avoid this, you can pass parameters to ``execute()``:
 
 Please note the question marks ``?`` in the SQL string that marks two parameters.
 Adding single rows at a time is not efficient. You can add more than just a single row to a table
-in efficiently by using ``executemany()``:
+efficiently by using ``executemany()``:
 
 ::
 

--- a/docs/pages/introduction.rst
+++ b/docs/pages/introduction.rst
@@ -2,9 +2,9 @@ Introduction
 ============
 
 Turbodbc is a Python module to access relational databases via the Open Database
-Connectivity (ODBC) interface. In addition to complying with the Python Database API
-Specification 2.0, turbodbc offers built-in NumPy support. Don't wait minutes for your
-results, just blink.
+Connectivity (ODBC) interface. In addition to complying with the
+`Python Database API Specification 2.0 <https://www.python.org/dev/peps/pep-0249/>`_,
+turbodbc offers built-in NumPy support. Don't wait minutes for your results, just blink.
 
 
 Features

--- a/docs/pages/odbc/concepts.rst
+++ b/docs/pages/odbc/concepts.rst
@@ -14,7 +14,7 @@ for some advanced usage patterns. But in essence, all ODBC drivers are born more
 less equal.
 
 ODBC drivers are easy to come by. Major database vendors offer ODBC drivers as free
-downloads (`Microsoft SQL server <https://www.microsoft.com/en-us/download/details.aspx?id=50420>`_,
+downloads (`Microsoft SQL Server <https://www.microsoft.com/en-us/download/details.aspx?id=50420>`_,
 `Exasol <https://www.exasol.com/portal/display/DOWNLOAD/6.0>`_,
 `Teradata <https://downloads.teradata.com/download/connectivity/odbc-driver/windows>`_, etc).
 Open source databases provide ODBC databases as part of their projects
@@ -25,7 +25,7 @@ Many ODBC drivers are also shipped with Linux distributions or are readily
 available via `Homebrew <https://github.com/Homebrew/homebrew-core>`_ for OSX.
 Last but not least, commercial ODBC drivers are available at
 `Progress <https://www.progress.com/odbc>`_ or `easysoft <http://www.easysoft.com/index.html>`_,
-claiming better performance that their freely available counterparts.
+claiming better performance than their freely available counterparts.
 
 
 .. _odbc_driver_manager:

--- a/docs/pages/odbc/concepts.rst
+++ b/docs/pages/odbc/concepts.rst
@@ -14,7 +14,7 @@ for some advanced usage patterns. But in essence, all ODBC drivers are born more
 less equal.
 
 ODBC drivers are easy to come by. Major database vendors offer ODBC drivers as free
-downloads (`Microsoft SQL Server <https://www.microsoft.com/en-us/download/details.aspx?id=50420>`_,
+downloads (`Microsoft SQL Server <https://www.microsoft.com/en-us/download/details.aspx?id=56567>`_,
 `Exasol <https://www.exasol.com/portal/display/DOWNLOAD/6.0>`_,
 `Teradata <https://downloads.teradata.com/download/connectivity/odbc-driver/windows>`_, etc).
 Open source databases provide ODBC databases as part of their projects

--- a/docs/pages/troubleshooting.rst
+++ b/docs/pages/troubleshooting.rst
@@ -23,7 +23,7 @@ it will not work with turbodbc.
 .. note::
 
     Before you file an issue with turbodbc, please make sure that you can actually
-    connect your database using ``isql``.
+    connect to your database using ``isql``.
 
 When you have selected an ODBC configuration as outlined above, enter the following
 command in a shell:
@@ -80,8 +80,10 @@ Troubleshooting:
 *   Check whether the library exists at the specified location.
 *   Check whether you have permission to *read* the library.
 *   Check whether the library depends on other shared libraries that are not present:
+
     *    On Linux, use ``ldd /path/to/library.so``
     *    On OSX, use ``otool -L /path/to/library.dylib``
+
 *   Check whether any superfluous non-printable characters are present in your ``odbc.ini``
     or ``odbcinst.ini`` near the ``Driver`` line. Been there, done that...
 
@@ -96,7 +98,7 @@ with your database. Here are a few common ones:
     locale settings. For example, unicode output may require a locale that supports
     UTF-8, such as ``en-US.utf-8``. Otherwise, replacement characters appear instead of
     unicode characters. Set the locale via environment variables such as ``LC_ALL``
-    or check whether your driver supports to set a locale in its connection options.
+    or check whether your driver supports setting a locale in its connection options.
 *   *Time zones*: ODBC does not feature a dedicated type that is aware of time zones or
     the distinction between local time and UTC. Some databases, however, feature separate
     types for, e.g., timestamps with and without time zone information. ODBC drivers now


### PR DESCRIPTION
This PR just fixes a few typos and makes other minor corrections to the turbodbc docs.  The only point of note would be the use of the "micro" [unicode symbol](https://www.fileformat.info/info/unicode/char/00b5/index.htm) (µ) in a few places to indicate microseconds, instead of "us".  Let me know if you don't want non-ascii characters in the docs.

The changes have been visually confirmed using [restview](https://pypi.org/project/restview/).