### PR TITLE
Fix the broken Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ matrix:
     osx_image: xcode9.4
     language: generic
     env:
-    - TRAVIS_PYTHON_VERSION="2.7.12"
+    - TRAVIS_PYTHON_VERSION="2.7.13"
     - TURBODBC_TEST_CONFIGURATION_FILES="query_fixtures_postgresql.json"
     - ODBC_DIR=odbc_osx
     - TURBODBC_ARROW_VERSION=0.13.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -220,6 +220,9 @@ before_script: |
       sudo apt-get update
       sudo ACCEPT_EULA=Y apt-get install msodbcsql17
       dpkg -L msodbcsql17
+      # sometimes MSSQL is not immediately available from the docker container, in which case
+      # pause for a few seconds, see: https://github.com/microsoft/mssql-docker/issues/203
+      docker exec -it mssql1 /opt/mssql-tools/bin/sqlcmd -S localhost -U SA -P 'StrongPassword1' -Q 'SELECT @@VERSION' || sleep 10
       docker exec -it mssql1 /opt/mssql-tools/bin/sqlcmd -S localhost -U SA -P 'StrongPassword1' -Q 'CREATE DATABASE test_db'
     fi
   fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
+os: linux
 dist: trusty
-sudo: required
+language: python
 
-matrix:
+jobs:
   include:
   - os: osx
     name: CPython2.7 Arrow 0.13.0
@@ -150,7 +151,7 @@ addons:
 
 before_install: |
   if [ "$TRAVIS_OS_NAME" == "osx" ]; then
-    HOMEBREW_NO_AUTO_UPDATE=1 brew install unixodbc pyenv-virtualenv pyenv-virtualenv psqlodbc
+    brew install unixodbc pyenv pyenv-virtualenv psqlodbc
     eval "$(pyenv init -)"
     eval "$(pyenv virtualenv-init -)"
     pyenv install ${TRAVIS_PYTHON_VERSION}
@@ -220,7 +221,7 @@ before_script: |
       sudo apt-get update
       sudo ACCEPT_EULA=Y apt-get install msodbcsql17
       dpkg -L msodbcsql17
-      # sometimes MSSQL is not immediately available from the docker container, in which case
+      # sometimes the first call to MSSQL in a docker container does not work, in which case
       # pause for a few seconds, see: https://github.com/microsoft/mssql-docker/issues/203
       docker exec -it mssql1 /opt/mssql-tools/bin/sqlcmd -S localhost -U SA -P 'StrongPassword1' -Q 'SELECT @@VERSION' || sleep 10
       docker exec -it mssql1 /opt/mssql-tools/bin/sqlcmd -S localhost -U SA -P 'StrongPassword1' -Q 'CREATE DATABASE test_db'


### PR DESCRIPTION
There are a couple of issues that were causing the build to fail, plus this PR cleans up a few other things in the Travis yaml file.

Python 2.7.12 no longer works on MacOSX builds, but 2.7.13+ builds do.  This appears to be because OpenSSL 1.0 was [removed](https://github.com/Homebrew/homebrew-core/issues/46454) from Homebrew at the end of 2019.  Python 2.7.13+ releases for MacOSX are either compatible with OpenSSL 1.1 or include OpenSSL 1.0 in their packages (2.7.13 thru 2.7.16 have been tested).  Hence, the "osx" build now uses Python 2.7.13.

Sometimes the Travis build failed because MSSQL was not available.  When the official MS SQL docker container is started, sometimes the first call to it can fail.  This is a known issue with that image and is described here: https://github.com/microsoft/mssql-docker/issues/203 .  This issue is intermittently causing the Travis build to fail, e.g. for [this build](https://travis-ci.org/blue-yonder/turbodbc/jobs/638918410?utm_medium=notification&utm_source=github_status) (see line 726 of the log).  To mitigate this issue, an extra SQL call is added before the SQL that creates the test_db database.  This "sacrificial" SQL call should allow the CREATE DATABASE statement to succeed, hopefully every time.

The https://config.travis-ci.com/explore utility recommended a couple of changes to `.travis.yml`:

- Removing `sudo: required` which is no longer needed in travis yaml files.
- Adding top-level entries for `os` and `language`.
- Replacing the outdated `matrix` keyword with `jobs`.

In `.travis.yml`, I have included a couple of other tidy ups:

- `HOMEBREW_NO_AUTO_UPDATE=1` is no longer needed, because the homebrew [issue](https://travis-ci.community/t/syntax-error-unexpected-keyword-rescue-expecting-keyword-end-in-homebrew/5623) has been fixed.
- `pyenv-virtualenv` is repeated in the `brew install` command, I'm assuming one of them was meant to be `pyenv`.
