### PR TITLE
Minimal python version to 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -100,6 +100,7 @@ addons:
 before_install: |
   if [ "$TRAVIS_OS_NAME" == "osx" ]; then
     brew install unixodbc pyenv pyenv-virtualenv psqlodbc boost
+    brew upgrade unixodbc pyenv pyenv-virtualenv psqlodbc boost
     eval "$(pyenv init -)"
     eval "$(pyenv virtualenv-init -)"
     pyenv install ${TRAVIS_PYTHON_VERSION}

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ jobs:
   include:
   - os: osx
     name: CPython3.6 Arrow 0.15.1
-    osx_image: xcode9.4
+    osx_image: xcode11.4
     language: generic
     env:
     - TRAVIS_PYTHON_VERSION="3.6.10"

--- a/.travis.yml
+++ b/.travis.yml
@@ -99,6 +99,8 @@ addons:
 
 before_install: |
   if [ "$TRAVIS_OS_NAME" == "osx" ]; then
+    brew update
+    brew upgrade
     brew install unixodbc pyenv pyenv-virtualenv psqlodbc boost
     eval "$(pyenv init -)"
     eval "$(pyenv virtualenv-init -)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,38 +5,14 @@ language: python
 jobs:
   include:
   - os: osx
-    name: CPython2.7 Arrow 0.15.1
+    name: CPython3.6 Arrow 0.15.1
     osx_image: xcode9.4
     language: generic
     env:
-    - TRAVIS_PYTHON_VERSION="2.7.13"
+    - TRAVIS_PYTHON_VERSION="3.6.10"
     - TURBODBC_TEST_CONFIGURATION_FILES="query_fixtures_postgresql.json"
     - ODBC_DIR=odbc_osx
     - TURBODBC_ARROW_VERSION=0.15.1
-#  Disable for now until a workaround for the detection of pyenv versions by pybind11
-#  is found
-#  - os: osx
-#    language: generic
-#    env:
-#    - TRAVIS_PYTHON_VERSION="3.6.0"
-#    - TURBODBC_TEST_CONFIGURATION_FILES="query_fixtures_postgresql.json"
-#    - ODBC_DIR=odbc_osx
-  - os: linux
-    name: CPython2.7 Arrow 0.15.1
-    language: python
-    python: "2.7"
-    env:
-    - TURBODBC_TEST_CONFIGURATION_FILES="query_fixtures_postgresql.json,query_fixtures_mysql.json"
-    - ODBC_DIR=odbc
-    - TURBODBC_ARROW_VERSION=0.15.1
-  - os: linux
-    name: CPython3.5 Arrow 0.15.1
-    language: python
-    python: "3.5"
-    env:
-    - TURBODBC_TEST_CONFIGURATION_FILES="query_fixtures_postgresql.json,query_fixtures_mysql.json"
-    - ODBC_DIR=odbc
-    - TURBODBC_ARROW_VERSION=0.16.0
   - os: linux
     name: CPython3.6 Arrow 0.16.0
     language: python
@@ -202,7 +178,6 @@ install: |
       pandas \
       pyarrow==$TURBODBC_ARROW_VERSION \
       pytest-cov \
-      six \
       twine
   fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -99,7 +99,7 @@ addons:
 
 before_install: |
   if [ "$TRAVIS_OS_NAME" == "osx" ]; then
-    brew install unixodbc pyenv pyenv-virtualenv psqlodbc boost ninja
+    brew install unixodbc pyenv pyenv-virtualenv psqlodbc boost
     eval "$(pyenv init -)"
     eval "$(pyenv virtualenv-init -)"
     pyenv install ${TRAVIS_PYTHON_VERSION}
@@ -210,12 +210,11 @@ script:
       ninja
     else
       if [ "$TRAVIS_OS_NAME" == "osx" ]; then
-        cmake -DBOOST_ROOT=/usr/local -DBUILD_COVERAGE=ON -DCMAKE_INSTALL_PREFIX=./dist -DPYBIND11_PYTHON_VERSION=${TRAVIS_PYTHON_VERSION} -GNinja ..
-        ninja
+        cmake -DBOOST_ROOT=/usr/local -DBUILD_COVERAGE=ON -DCMAKE_INSTALL_PREFIX=./dist -DPYBIND11_PYTHON_VERSION=${TRAVIS_PYTHON_VERSION} ..
       else
         cmake -DBUILD_COVERAGE=ON -DCMAKE_INSTALL_PREFIX=./dist -DPYBIND11_PYTHON_VERSION=${TRAVIS_PYTHON_VERSION} ..
-        make -j4
       fi
+      make -j4
     fi
   - |
       if [ "$TRAVIS_OS_NAME" == "osx" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -99,7 +99,7 @@ addons:
 
 before_install: |
   if [ "$TRAVIS_OS_NAME" == "osx" ]; then
-    brew install unixodbc pyenv pyenv-virtualenv psqlodbc
+    brew install unixodbc pyenv pyenv-virtualenv psqlodbc boost ninja
     eval "$(pyenv init -)"
     eval "$(pyenv virtualenv-init -)"
     pyenv install ${TRAVIS_PYTHON_VERSION}
@@ -209,8 +209,13 @@ script:
       cmake -DBOOST_ROOT=$CONDA_PREFIX -DBUILD_COVERAGE=ON -DCMAKE_INSTALL_PREFIX=./dist  -DPYTHON_EXECUTABLE=`which python` -GNinja ..
       ninja
     else
-      cmake -DBUILD_COVERAGE=ON -DCMAKE_INSTALL_PREFIX=./dist -DPYBIND11_PYTHON_VERSION=${TRAVIS_PYTHON_VERSION} ..
-      make -j4
+      if [ "$TRAVIS_OS_NAME" == "osx" ]; then
+        cmake -DBOOST_ROOT=/usr/local -DBUILD_COVERAGE=ON -DCMAKE_INSTALL_PREFIX=./dist -DPYBIND11_PYTHON_VERSION=${TRAVIS_PYTHON_VERSION} -GNinja ..
+        ninja
+      else
+        cmake -DBUILD_COVERAGE=ON -DCMAKE_INSTALL_PREFIX=./dist -DPYBIND11_PYTHON_VERSION=${TRAVIS_PYTHON_VERSION} ..
+        make -j4
+      fi
     fi
   - |
       if [ "$TRAVIS_OS_NAME" == "osx" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ jobs:
   include:
   - os: osx
     name: CPython3.6 Arrow 0.15.1
-    osx_image: xcode11.4
+    osx_image: xcode9.4
     language: generic
     env:
     - TRAVIS_PYTHON_VERSION="3.6.10"
@@ -99,8 +99,6 @@ addons:
 
 before_install: |
   if [ "$TRAVIS_OS_NAME" == "osx" ]; then
-    brew update
-    brew upgrade
     brew install unixodbc pyenv pyenv-virtualenv psqlodbc boost
     eval "$(pyenv init -)"
     eval "$(pyenv virtualenv-init -)"

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,11 @@ Version history / changelog
 
 From version 2.0.0, turbodbc adapts semantic versioning.
 
+Version 4.0.0
+-------------
+
+* Minimal supported python version is 3.6.X now
+
 Version 3.4.0
 -------------
 

--- a/cpp/turbodbc_numpy/Library/src/python_bindings.cpp
+++ b/cpp/turbodbc_numpy/Library/src/python_bindings.cpp
@@ -29,21 +29,11 @@ void set_numpy_parameters(turbodbc::cursor & cursor, std::vector<std::tuple<pybi
 
 }
 
-// this function is required to work around issues and compiler warnings with
-// the import_array() macro on systems with Python 2/3
-#if PY_VERSION_HEX >= 0x03000000
-    void * enable_numpy_support()
-    {
-        import_array();
-        return nullptr;
-    }
-#else
-    void enable_numpy_support()
-    {
-        import_array();
-    }
-#endif
-
+void * enable_numpy_support()
+{
+    import_array();
+    return nullptr;
+}
 
 PYBIND11_MODULE(turbodbc_numpy_support, module) {
     enable_numpy_support();

--- a/docs/pages/introduction.rst
+++ b/docs/pages/introduction.rst
@@ -20,7 +20,7 @@ Features
 *   Supported data types for both result sets and parameters:
     ``int``, ``float``, ``str``, ``bool``, ``datetime.date``, ``datetime.datetime``
 *   Also provides a high-level C++11 database driver under the hood
-*   Tested with Python 2.7, 3.5, and 3.6
+*   Tested with Python 3.6, 3.7 and 3.8
 *   Tested on 64 bit versions of Linux, OSX, and Windows (Python 3.5+).
 
 
@@ -72,7 +72,7 @@ Supported environments
 *   Linux (successfully built on Ubuntu 12, Ubuntu 14, Debian 7, Debian 8)
 *   OSX (successfully built on Sierra a.k.a. 10.12 and El Capitan a.k.a. 10.11)
 *   Windows (successfully built on Windows 10)
-*   Python 2.7, 3.5, 3.6
+*   Python 3.6, 3.7, 3.8
 *   More environments probably work as well, but these are the versions that
     are regularly tested on Travis or local development machines.
 

--- a/python/turbodbc/__init__.py
+++ b/python/turbodbc/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from .api_constants import apilevel, threadsafety, paramstyle
 from .connect import connect
 from .constructors import Date, Time, Timestamp

--- a/python/turbodbc/connect.py
+++ b/python/turbodbc/connect.py
@@ -1,8 +1,3 @@
-from __future__ import absolute_import
-
-import warnings
-import six
-
 from turbodbc_intern import connect as intern_connect
 
 from .exceptions import translate_exceptions, ParameterError
@@ -12,7 +7,7 @@ from .options import make_options
 def _make_connection_string(dsn, **kwargs):
     if dsn:
         kwargs['dsn'] = dsn
-    return ';'.join(["{}={}".format(key, value) for key, value in six.iteritems(kwargs)])
+    return ';'.join(["{}={}".format(key, value) for key, value in kwargs.items()])
 
 
 @translate_exceptions

--- a/python/turbodbc/connection.py
+++ b/python/turbodbc/connection.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from weakref import WeakSet
 
 from .exceptions import translate_exceptions, InterfaceError

--- a/python/turbodbc/cursor.py
+++ b/python/turbodbc/cursor.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from itertools import islice
 from collections import OrderedDict
 
@@ -81,8 +79,6 @@ class Cursor(object):
             raise StopIteration
         else:
             return element
-
-    next = __next__  # Python 2 compatibility
 
     def _assert_valid(self):
         if self.impl is None:

--- a/python/turbodbc/exceptions.py
+++ b/python/turbodbc/exceptions.py
@@ -1,19 +1,10 @@
-from __future__ import absolute_import
-
 from functools import wraps
 
 from turbodbc_intern import Error as InternError
 from turbodbc_intern import InterfaceError as InternInterfaceError
 
 
-# Python 2/3 compatibility
-try:
-    from exceptions import StandardError as _BaseError
-except ImportError:
-    _BaseError = Exception
-
-
-class Error(_BaseError):
+class Error(Exception):
     """
     turbodbc's basic error class
     """
@@ -32,7 +23,7 @@ class DatabaseError(Error):
     An error that is raised when the database encounters an error while processing
     your commands and queries
     """
-    pass 
+    pass
 
 
 class ParameterError(Error):

--- a/python/turbodbc_test/test_cursor_async_io.py
+++ b/python/turbodbc_test/test_cursor_async_io.py
@@ -1,7 +1,4 @@
 import pytest
-import six
-
-from turbodbc import connect
 
 from query_fixture import query_fixture
 from helpers import for_one_database, open_cursor
@@ -13,7 +10,7 @@ def test_many_batches_with_async_io(dsn, configuration):
         with query_fixture(cursor, configuration, 'INSERT INTEGER') as table_name:
             # insert 2^16 rows
             cursor.execute("INSERT INTO {} VALUES (1)".format(table_name))
-            for _ in six.moves.range(16):
+            for _ in range(16):
                 cursor.execute("INSERT INTO {} SELECT * FROM {}".format(table_name,
                                                                         table_name))
 

--- a/python/turbodbc_test/test_cursor_basics.py
+++ b/python/turbodbc_test/test_cursor_basics.py
@@ -1,5 +1,4 @@
 import pytest
-import six
 
 from turbodbc import connect, InterfaceError, Error, DatabaseError
 
@@ -44,7 +43,7 @@ def test_closed_cursor_raises_when_used(dsn, configuration):
         cursor.fetchall()
 
     with pytest.raises(InterfaceError):
-        six.next(cursor)
+        next(cursor)
 
 
 @for_one_database

--- a/python/turbodbc_test/test_cursor_insert.py
+++ b/python/turbodbc_test/test_cursor_insert.py
@@ -1,5 +1,4 @@
 import datetime
-import six
 
 from query_fixture import query_fixture
 from helpers import for_each_database, for_one_database, open_cursor, generate_microseconds_with_precision
@@ -192,8 +191,8 @@ def test_insert_empty_parameter_list(dsn, configuration):
 def test_insert_number_of_rows_exceeds_buffer_size(dsn, configuration):
     buffer_size = 3
     numbers = buffer_size * 2 + 1
-    data = [[i] for i in six.moves.range(numbers)]
-    
+    data = [[i] for i in range(numbers)]
+
     with open_cursor(configuration, parameter_sets_to_buffer=buffer_size) as cursor:
         with query_fixture(cursor, configuration, 'INSERT INTEGER') as table_name:
             cursor.executemany("INSERT INTO {} VALUES (?)".format(table_name), data)

--- a/python/turbodbc_test/test_cursor_select.py
+++ b/python/turbodbc_test/test_cursor_select.py
@@ -1,6 +1,5 @@
 import datetime
 import pytest
-import six
 
 import turbodbc
 
@@ -11,15 +10,15 @@ from helpers import open_cursor, for_each_database, for_one_database, for_each_d
 def _test_single_row_result_set(configuration, query, expected_row):
     with open_cursor(configuration) as cursor:
         cursor.execute(query)
-    
+
         if configuration["capabilities"]['supports_row_count']:
             assert cursor.rowcount == 1
         else:
             assert cursor.rowcount == -1
-    
+
         row = cursor.fetchone()
         assert row == expected_row
-    
+
         row = cursor.fetchone()
         assert None == row
 
@@ -138,7 +137,7 @@ def test_fetchone(dsn, configuration):
             assert row == [43]
             row = cursor.fetchone()
             assert row == [44]
-    
+
             row = cursor.fetchone()
             assert None == row
 
@@ -236,13 +235,13 @@ def test_number_of_rows_exceeds_buffer_size(dsn, configuration):
     with open_cursor(configuration, rows_to_buffer=buffer_size) as cursor:
         with query_fixture(cursor, configuration, 'INSERT INTEGER') as table_name:
             numbers = buffer_size * 2 + 1
-            for i in six.moves.range(numbers):
+            for i in range(numbers):
                 cursor.execute("INSERT INTO {} VALUES ({})".format(table_name, i))
 
             cursor.execute("SELECT a FROM {}".format(table_name))
             retrieved = cursor.fetchall()
             actual_sum = sum([row[0] for row in retrieved])
-            expected_sum = sum(six.moves.range(numbers))
+            expected_sum = sum(range(numbers))
             assert expected_sum == actual_sum
 
 

--- a/python/turbodbc_test/test_has_arrow_support.py
+++ b/python/turbodbc_test/test_has_arrow_support.py
@@ -2,7 +2,6 @@ from mock import patch
 
 from turbodbc.cursor import _has_arrow_support
 
-import six
 import pytest
 
 # Skip all parquet tests if we can't import pyarrow.parquet
@@ -11,13 +10,10 @@ pytest.importorskip('pyarrow')
 # Ignore these with pytest ... -m 'not parquet'
 pyarrow = pytest.mark.pyarrow
 
-# Python 2/3 compatibility
-_IMPORT_FUNCTION_NAME = "{}.__import__".format(six.moves.builtins.__name__)
-
 
 @pyarrow
 def test_has_arrow_support_fails():
-    with patch(_IMPORT_FUNCTION_NAME, side_effect=ImportError):
+    with patch("builtins.__import__", side_effect=ImportError):
         assert _has_arrow_support() == False
 
 

--- a/python/turbodbc_test/test_has_numpy_support.py
+++ b/python/turbodbc_test/test_has_numpy_support.py
@@ -1,18 +1,23 @@
-import six
-
 from mock import patch
 
 from turbodbc.cursor import _has_numpy_support
 
+import pytest
 
-# Python 2/3 compatibility
-_IMPORT_FUNCTION_NAME = "{}.__import__".format(six.moves.builtins.__name__)
+# Skip all parquet tests if we can't import pyarrow.parquet
+pytest.importorskip('numpy')
+
+# Ignore these with pytest ... -m 'not parquet'
+numpy = pytest.mark.numpy
 
 
+# Skip all parquet tests if we can't import pyarrow.parquet
+@pytest.mark.numpy
 def test_has_numpy_support_fails():
-    with patch(_IMPORT_FUNCTION_NAME, side_effect=ImportError):
+    with patch("builtins.__import__", side_effect=ImportError):
         assert _has_numpy_support() == False
 
 
+@pytest.mark.numpy
 def test_has_numpy_support_succeeds():
     assert _has_numpy_support() == True

--- a/setup.py
+++ b/setup.py
@@ -205,7 +205,7 @@ with open(os.path.join(here, 'README.md')) as f:
 
 
 setup(name = 'turbodbc',
-      version = '3.4.0',
+      version = '4.0.0',
       description = 'turbodbc is a Python DB API 2.0 compatible ODBC driver',
       long_description=long_description,
       long_description_content_type='text/markdown',
@@ -226,14 +226,11 @@ setup(name = 'turbodbc',
                      'Operating System :: MacOS :: MacOS X',
                      'Operating System :: Microsoft :: Windows',
                      'Programming Language :: C++',
-                     'Programming Language :: Python :: 2.7',
-                     'Programming Language :: Python :: 3.4',
-                     'Programming Language :: Python :: 3.5',
                      'Programming Language :: Python :: 3.6',
                      'Programming Language :: Python :: 3.7',
                      'Programming Language :: Python :: 3.8',
                      'Programming Language :: Python :: Implementation :: CPython',
                      'Topic :: Database'],
       ext_modules = get_extension_modules(),
-      install_requires=['pybind11>=2.2.0', 'six']
+      install_requires=['pybind11>=2.2.0']
       )


### PR DESCRIPTION
The py2 builds are currently flaky and the last release failed because of it. I suggest to drop py2 now and release a 4.0 version instead of fixing the old build.

Code changes where mostly grepping for py2 but there might be additional dead compat code somewhere.

Closes #253
Closes #259 
Fixes #261