### PR TITLE
Allow arrow >1.0.X

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,6 +82,26 @@ jobs:
     - ODBC_DIR=odbc
     - TURBODBC_ARROW_VERSION=0.17.1
   - os: linux
+    name: CPython3.8 Arrow 1.0.1
+    dist: xenial
+    language: python
+    addons:
+      apt:
+        packages:
+          - unixodbc
+          - unixodbc-dev
+          - odbc-postgresql
+    services:
+      - docker
+      - postgresql
+      - mysql
+    python: "3.8"
+    env:
+    - TURBODBC_USE_CONDA=yes
+    - TURBODBC_TEST_CONFIGURATION_FILES="query_fixtures_postgresql.json,query_fixtures_mssql.json"
+    - ODBC_DIR=odbc
+    - TURBODBC_ARROW_VERSION=1.0.1
+  - os: linux
     name: CPython3.8 Arrow Nightlies
     dist: xenial
     language: python
@@ -248,8 +268,8 @@ script:
   - cd gcov
   - gcov -l -p `find ../build -name "*.gcda"` > /dev/null
   - echo "Removing coverage for boost and C++ standard library"
-  - find . -name "*#boost#*" | xargs rm
-  - find . -name "*#c++#*" | xargs rm
+  - (find . -name "*#boost#*" | xargs rm) || echo "error while removing boost files"
+  - (find . -name "*#c++#*" | xargs rm) || echo "error while removing stdlib files"
   - cd ..
   - cd python/turbodbc_test/
   - echo "Uploading Python coverage"

--- a/setup.py
+++ b/setup.py
@@ -215,8 +215,7 @@ setup(name = 'turbodbc',
       author_email = 'michael.koenig@blue-yonder.com',
       packages = ['turbodbc'],
       extras_require={
-          # We pin Apache Arrow quite restrictively until they guarantee a stable API
-          'arrow': ['pyarrow>=0.15,<0.18'],
+          'arrow': ['pyarrow>=0.15,<2.0'],
           'numpy': 'numpy>=1.16.0'
       },
       classifiers = ['Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
I do get some errors for the coverage collection but not for all builds. I can't really track down the issue and I can't reproduce this locally. 
Instead I'll just print an error in these scenarios