### PR TITLE
update the arrow install requirements to limit it only downwards to >=0.17.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ From version 2.0.0, turbodbc adapts semantic versioning.
 Version 4.1.2
 -------------
 
-* Update package requirements so pyarrow<2.0 can be used.
+* Update package requirements so pyarrow>0.17.1 with no upper limit can be used.
 
 Version 4.1.1
 -------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ From version 2.0.0, turbodbc adapts semantic versioning.
 Version 4.1.2
 -------------
 
-* Update package requirements so pyarrow>0.17.1 with no upper limit can be used.
+* Update package requirements so pyarrow>0.17.1,<3.1 can be used.
 
 Version 4.1.1
 -------------

--- a/Earthfile
+++ b/Earthfile
@@ -162,7 +162,7 @@ test-python3.8-arrow1.x.x:
 test-python3.8-arrow2.x.x:
     ARG PYTHON_VERSION="3.8.5"
     COPY --build-arg PYTHON_VERSION="$PYTHON_VERSION" \
-        --build-arg ARROW_VERSION_RULE=">=2,<3" \
+        --build-arg ARROW_VERSION_RULE=">=2,<3.1" \
         --build-arg NUMPY_VERSION_RULE=">=1.20.0" \
         +test/result /result
 

--- a/setup.py
+++ b/setup.py
@@ -215,7 +215,7 @@ setup(name = 'turbodbc',
       author_email = 'michael.koenig@blue-yonder.com',
       packages = ['turbodbc'],
       extras_require={
-          'arrow': ['pyarrow>=0.17.1'],
+          'arrow': ['pyarrow>=0.15,<3.1.0'],
           'numpy': 'numpy>=1.16.0'
       },
       classifiers = ['Development Status :: 5 - Production/Stable',

--- a/setup.py
+++ b/setup.py
@@ -215,7 +215,7 @@ setup(name = 'turbodbc',
       author_email = 'michael.koenig@blue-yonder.com',
       packages = ['turbodbc'],
       extras_require={
-          'arrow': ['pyarrow>=0.15,<2.0'],
+          'arrow': ['pyarrow>=0.17.1'],
           'numpy': 'numpy>=1.16.0'
       },
       classifiers = ['Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
the test pipelines work for arrow >=3.0.0 as well so we should allow
it for install as well