### PR TITLE
Update pyarrow, numpy and python versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,6 @@ jobs:
     strategy:
       matrix:
         target:
-          - +test-python3.6
           - +test-python3.8-arrow0.x.x
           - +test-python3.8-arrow1.x.x
           - +test-python3.8-arrow2.x.x

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ other popular ODBC modules do.
 
 Turbodbc is free to use ([MIT license](https://github.com/blue-yonder/turbodbc/blob/master/LICENSE)),
 open source ([GitHub](https://github.com/blue-yonder/turbodbc)),
-works with Python 3.6+, and is available for Linux, macOS, and Windows.
+works with Python 3.7+, and is available for Linux, macOS, and Windows.
 
 Turbodbc is routinely tested with [MySQL](https://www.mysql.com),
 [PostgreSQL](https://www.postgresql.org), [EXASOL](http://www.exasol.com),

--- a/docs/pages/introduction.rst
+++ b/docs/pages/introduction.rst
@@ -20,8 +20,8 @@ Features
 *   Supported data types for both result sets and parameters:
     ``int``, ``float``, ``str``, ``bool``, ``datetime.date``, ``datetime.datetime``
 *   Also provides a high-level C++11 database driver under the hood
-*   Tested with Python 3.6, 3.7 and 3.8
-*   Tested on 64 bit versions of Linux, OSX, and Windows (Python 3.5+).
+*   Tested with Python 3.7, 3.8 and 3.9
+*   Tested on 64 bit versions of Linux, OSX, and Windows (Python 3.7+).
 
 
 Why should I use turbodbc instead of other ODBC modules?
@@ -72,7 +72,7 @@ Supported environments
 *   Linux (successfully built on Ubuntu 12, Ubuntu 14, Debian 7, Debian 8)
 *   OSX (successfully built on Sierra a.k.a. 10.12 and El Capitan a.k.a. 10.11)
 *   Windows (successfully built on Windows 10)
-*   Python 3.6, 3.7, 3.8
+*   Python 3.7, 3.8, 3.9
 *   More environments probably work as well, but these are the versions that
     are regularly tested on Travis or local development machines.
 

--- a/earthly/odbc/odbcinst.ini
+++ b/earthly/odbc/odbcinst.ini
@@ -10,4 +10,4 @@ Threading   = 2
 
 [ODBC Driver 17 for SQL Server]
 Description = Microsoft ODBC Driver 17 for SQL Server
-Driver      = /opt/microsoft/msodbcsql17/lib64/libmsodbcsql-17.7.so.1.1
+Driver      = /opt/microsoft/msodbcsql17/lib64/libmsodbcsql-17.7.so.2.1

--- a/setup.py
+++ b/setup.py
@@ -205,7 +205,7 @@ with open(os.path.join(here, 'README.md')) as f:
 
 
 setup(name = 'turbodbc',
-      version = '4.1.2',
+      version = '4.2.0',
       description = 'turbodbc is a Python DB API 2.0 compatible ODBC driver',
       long_description=long_description,
       long_description_content_type='text/markdown',
@@ -215,8 +215,8 @@ setup(name = 'turbodbc',
       author_email = 'michael.koenig@blue-yonder.com',
       packages = ['turbodbc'],
       extras_require={
-          'arrow': ['pyarrow>=0.15,<3.1.0'],
-          'numpy': 'numpy>=1.16.0'
+          'arrow': ['pyarrow>=0.15,<4.1.0'],
+          'numpy': 'numpy>=1.17.0'
       },
       classifiers = ['Development Status :: 5 - Production/Stable',
                      'Intended Audience :: Developers',
@@ -225,7 +225,6 @@ setup(name = 'turbodbc',
                      'Operating System :: MacOS :: MacOS X',
                      'Operating System :: Microsoft :: Windows',
                      'Programming Language :: C++',
-                     'Programming Language :: Python :: 3.6',
                      'Programming Language :: Python :: 3.7',
                      'Programming Language :: Python :: 3.8',
                      'Programming Language :: Python :: 3.9',


### PR DESCRIPTION
Allowing pyarrow==4.0.0 and following NEP 29, increasing minimum versions:
- Numpy 1.16->1.17
- Python 3.6->3.7