### PR TITLE
Initialize PyDateTimeAPI in module initialization.

### DIFF
--- a/cpp/turbodbc_python/Library/src/determine_parameter_type.cpp
+++ b/cpp/turbodbc_python/Library/src/determine_parameter_type.cpp
@@ -100,6 +100,9 @@ python_parameter_info determine_parameter_type(pybind11::handle const & value, t
     }
 
     auto ptr = value.ptr();
+    if (!PyDateTimeAPI) {
+        PyDateTime_IMPORT;
+    }
     if (PyDateTime_Check(ptr)) {
         return {set_timestamp, type_code::timestamp, size_not_important};
     }

--- a/cpp/turbodbc_python/Library/src/determine_parameter_type.cpp
+++ b/cpp/turbodbc_python/Library/src/determine_parameter_type.cpp
@@ -9,15 +9,6 @@ namespace turbodbc {
 
 namespace {
 
-    struct datetime_initializer {
-        datetime_initializer()
-        {
-            PyDateTime_IMPORT;
-        }
-    };
-
-    static const datetime_initializer required_for_datetime_interaction;
-
     std::size_t const size_not_important = 0;
 
     void set_integer(pybind11::handle const & value, cpp_odbc::writable_buffer_element & destination)

--- a/cpp/turbodbc_python/Library/src/determine_parameter_type.cpp
+++ b/cpp/turbodbc_python/Library/src/determine_parameter_type.cpp
@@ -70,6 +70,9 @@ namespace {
 
 }
 
+void determine_parameter_type_init(){
+    PyDateTime_IMPORT;
+}
 
 python_parameter_info determine_parameter_type(pybind11::handle const & value, type_code initial_type)
 {
@@ -100,9 +103,6 @@ python_parameter_info determine_parameter_type(pybind11::handle const & value, t
     }
 
     auto ptr = value.ptr();
-    if (!PyDateTimeAPI) {
-        PyDateTime_IMPORT;
-    }
     if (PyDateTime_Check(ptr)) {
         return {set_timestamp, type_code::timestamp, size_not_important};
     }

--- a/cpp/turbodbc_python/Library/src/python_bindings/module.cpp
+++ b/cpp/turbodbc_python/Library/src/python_bindings/module.cpp
@@ -12,13 +12,21 @@ namespace turbodbc { namespace bindings {
     void for_python_result_set(pybind11::module &);
     void for_python_parameter_set(pybind11::module &);
 
-} }
+}
+namespace result_sets {
+    void python_result_set_init();
+}
+    void determine_parameter_type_init();
+}
 
 
 using namespace turbodbc;
 
 PYBIND11_MODULE(turbodbc_intern, module)
 {
+    result_sets::python_result_set_init();
+    determine_parameter_type_init();
+
     module.doc() = "Native helpers for the turbodbc package";
     bindings::for_buffer_size(module);
     bindings::for_column_info(module);

--- a/cpp/turbodbc_python/Library/src/python_bindings/module.cpp
+++ b/cpp/turbodbc_python/Library/src/python_bindings/module.cpp
@@ -1,5 +1,7 @@
 #include <pybind11/pybind11.h>
 
+#include <datetime.h> // Python header
+
 namespace turbodbc { namespace bindings {
 
     void for_buffer_size(pybind11::module &);
@@ -19,6 +21,9 @@ using namespace turbodbc;
 
 PYBIND11_MODULE(turbodbc_intern, module)
 {
+    // determine_parameter_type relies on PyDateTimeAPI
+    PyDateTime_IMPORT;
+
     module.doc() = "Native helpers for the turbodbc package";
     bindings::for_buffer_size(module);
     bindings::for_column_info(module);

--- a/cpp/turbodbc_python/Library/src/python_bindings/module.cpp
+++ b/cpp/turbodbc_python/Library/src/python_bindings/module.cpp
@@ -1,7 +1,5 @@
 #include <pybind11/pybind11.h>
 
-#include <datetime.h> // Python header
-
 namespace turbodbc { namespace bindings {
 
     void for_buffer_size(pybind11::module &);
@@ -21,9 +19,6 @@ using namespace turbodbc;
 
 PYBIND11_MODULE(turbodbc_intern, module)
 {
-    // determine_parameter_type relies on PyDateTimeAPI
-    PyDateTime_IMPORT;
-
     module.doc() = "Native helpers for the turbodbc package";
     bindings::for_buffer_size(module);
     bindings::for_column_info(module);

--- a/cpp/turbodbc_python/Library/src/python_result_set.cpp
+++ b/cpp/turbodbc_python/Library/src/python_result_set.cpp
@@ -58,14 +58,14 @@ namespace {
 
 }
 
+void python_result_set_init() {
+    PyDateTime_IMPORT;
+}
 
 python_result_set::python_result_set(result_set & base) :
     row_based_(base),
     columns_(row_based_.get_column_info())
 {
-    if(!PyDateTimeAPI) {
-        PyDateTime_IMPORT;
-    }
 }
 
 std::vector<column_info> python_result_set::get_column_info() const

--- a/cpp/turbodbc_python/Library/src/python_result_set.cpp
+++ b/cpp/turbodbc_python/Library/src/python_result_set.cpp
@@ -63,7 +63,9 @@ python_result_set::python_result_set(result_set & base) :
     row_based_(base),
     columns_(row_based_.get_column_info())
 {
-    PyDateTime_IMPORT;
+    if(!PyDateTimeAPI) {
+        PyDateTime_IMPORT;
+    }
 }
 
 std::vector<column_info> python_result_set::get_column_info() const


### PR DESCRIPTION
The static initialization causes import errors on Windows with Python
3.8 and 3.9.

This fixes the import errors on Windows with newer Python versions.