### PR TITLE
fix rst syntax

### DIFF
--- a/python/turbodbc/options.py
+++ b/python/turbodbc/options.py
@@ -54,13 +54,13 @@ def make_options(read_buffer_size=None,
      report a size of 2 billion characters.
      Please note that this option only relates to retrieving results, not sending parameters to the
      database.
-    :param force_extra_capacity_for_unicode Affects behavior/performance. Some ODBC drivers report the
+    :param force_extra_capacity_for_unicode: Affects behavior/performance. Some ODBC drivers report the
      length of the ``VARCHAR``/``NVARCHAR`` field rather than the number of code points for which space is required
      to be allocated, resulting in string truncations. Set this option to ``True`` to increase the memory
      allocated for ``VARCHAR`` and ``NVARCHAR`` fields and prevent string truncations.
      Please note that this option only relates to retrieving results, not sending parameters to the
      database.
-    :param fetch_wchar_as_char Affects behavior. Some ODBC drivers retrieve single byte encoded strings
+    :param fetch_wchar_as_char: Affects behavior. Some ODBC drivers retrieve single byte encoded strings
      into ``NVARCHAR`` fields of result sets, which are decoded incorrectly by turbodbc default settings,
      resulting in corrupt strings. Set this option to ``True`` to have turbodbc treat ``NVARCHAR`` types
      as narrow character types when decoding the fields in result sets.


### PR DESCRIPTION
Fix minor error, causing parameters to be rendered incorrectly on readthedocs.org