### PR TITLE
Release the GIL in python_parameter_set::flush

### DIFF
--- a/cpp/turbodbc_python/Library/src/python_parameter_set.cpp
+++ b/cpp/turbodbc_python/Library/src/python_parameter_set.cpp
@@ -22,6 +22,10 @@ python_parameter_set::~python_parameter_set() = default;
 
 void python_parameter_set::flush()
 {
+	// release the GIL here because bound_parameter_set::execute_batch may perform
+	// a blocking ODBC call (statement::execute_prepared)
+	pybind11::gil_scoped_release release;
+
 	// bound result set handles empty parameter sets
 	parameters_.execute_batch(current_parameter_set_);
 	current_parameter_set_ = 0;


### PR DESCRIPTION
Resolves #193, resolves #283 

When executing a parametrized query, the ``turbodbc.cursor.execute()`` method calls ``python_parameter_set.flush()`` which makes ODBC API calls without releasing the GIL. This blocks the whole python process until the call returns. In the worst case scenario, a deadlock can occur if the operation tries to acquire a database lock which is already held by another thread in the same process.

I believe it is safe to release the GIL at this point because the ``bound_parameter_set`` class does not interact with any python objects.

Fix was tested using the sample code provided in #193 (thanks @korobkov-mindbox)