### PR TITLE
Update 3rd parties

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,8 +62,8 @@ jobs:
             upload: false
     steps:
       - uses: actions/checkout@v2
-      - name: Download earthly 0.5.24
-        run: "sudo /bin/sh -c 'wget https://github.com/earthly/earthly/releases/download/v0.5.24/earthly-linux-amd64 -O /usr/local/bin/earthly && chmod +x /usr/local/bin/earthly'"
+      - name: Download earthly 0.5.0
+        run: "sudo /bin/sh -c 'wget https://github.com/earthly/earthly/releases/download/v0.5.0/earthly-linux-amd64 -O /usr/local/bin/earthly && chmod +x /usr/local/bin/earthly'"
       - name: Run build
         run: earthly --allow-privileged ${{ matrix.target }}
         continue-on-error: ${{ matrix.experimental }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,8 +62,8 @@ jobs:
             upload: false
     steps:
       - uses: actions/checkout@v2
-      - name: Download earthly 0.6.7
-        run: "sudo /bin/sh -c 'wget https://github.com/earthly/earthly/releases/download/v0.6.7/earthly-linux-amd64 -O /usr/local/bin/earthly && chmod +x /usr/local/bin/earthly'"
+      - name: Download earthly 0.5.24
+        run: "sudo /bin/sh -c 'wget https://github.com/earthly/earthly/releases/download/v0.5.24/earthly-linux-amd64 -O /usr/local/bin/earthly && chmod +x /usr/local/bin/earthly'"
       - name: Run build
         run: earthly --allow-privileged ${{ matrix.target }}
         continue-on-error: ${{ matrix.experimental }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,6 @@ jobs:
     strategy:
       matrix:
         target:
-          - +test-python3.8-arrow0.x.x
           - +test-python3.8-arrow1.x.x
           - +test-python3.8-arrow2.x.x
           - +test-python3.8-arrow3.x.x
@@ -26,7 +25,6 @@ jobs:
           - +test-python3.8-arrow5.x.x
           - +test-python3.8-arrow6.x.x
           - +test-python3.8-arrow7.x.x
-          - +test-python3.9-arrow0.x.x
           - +test-python3.9-arrow1.x.x
           - +test-python3.9-arrow2.x.x
           - +test-python3.9-arrow3.x.x
@@ -64,8 +62,8 @@ jobs:
             upload: false
     steps:
       - uses: actions/checkout@v2
-      - name: Download earthly 5.0.0
-        run: "sudo /bin/sh -c 'wget https://github.com/earthly/earthly/releases/download/v0.5.0/earthly-linux-amd64 -O /usr/local/bin/earthly && chmod +x /usr/local/bin/earthly'"
+      - name: Download earthly 0.6.7
+        run: "sudo /bin/sh -c 'wget https://github.com/earthly/earthly/releases/download/v0.6.7/earthly-linux-amd64 -O /usr/local/bin/earthly && chmod +x /usr/local/bin/earthly'"
       - name: Run build
         run: earthly --allow-privileged ${{ matrix.target }}
         continue-on-error: ${{ matrix.experimental }}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,13 @@ Version history / changelog
 
 From version 2.0.0, turbodbc adapts semantic versioning.
 
+Version 4.4.0
+-------------
+
+* Bump pybind11 version to 2.9.1
+* Bump dependency requirements to ``pyarrow>=1.0`` and ``numpy>=1.19``
+* Bump the used earthly and google test versions to 0.6.7 and 1.11.0 resp.
+
 Version 4.3.1
 -------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,7 @@ Version 4.4.0
 
 * Bump pybind11 version to 2.9.1
 * Bump dependency requirements to ``pyarrow>=1.0`` and ``numpy>=1.19``
-* Bump the used earthly and google test versions to 0.6.7 and 1.11.0 resp.
+* Bump the used google test versions to 1.11.0
 
 Version 4.3.1
 -------------

--- a/Earthfile
+++ b/Earthfile
@@ -62,8 +62,8 @@ python:
     RUN echo 'export UNIXODBC_INCLUDE_DIR=$CONDA_PREFIX/include' >> ~/.bashrc
 
     RUN cd /opt && \
-        wget -q https://github.com/pybind/pybind11/archive/v2.8.1.tar.gz && \
-        tar xvf v2.8.1.tar.gz
+        wget -q https://github.com/pybind/pybind11/archive/v2.9.1.tar.gz && \
+        tar xvf v2.9.1.tar.gz
 
 build:
     ARG PYTHON_VERSION=3.8.12
@@ -83,7 +83,7 @@ build:
 
     ENV ODBCSYSINI=/src/earthly/odbc
     ENV TURBODBC_TEST_CONFIGURATION_FILES="query_fixtures_postgresql.json,query_fixtures_mssql.json,query_fixtures_mysql.json"
-    RUN ln -s /opt/pybind11-2.8.1 /src/pybind11
+    RUN ln -s /opt/pybind11-2.9.1 /src/pybind11
 
     RUN bash -ic " \
         cmake -DBOOST_ROOT=\${CONDA_PREFIX} -DBUILD_COVERAGE=ON \
@@ -129,15 +129,6 @@ test:
     SAVE ARTIFACT python_cov.xml /result/cov/python/python_cov.xml
     SAVE ARTIFACT ../gcov /result/cov/cpp
     SAVE ARTIFACT /src/build/dist/dist /result/dist
-
-test-python3.8-arrow0.x.x:
-    ARG PYTHON_VERSION="3.8.12"
-    COPY --build-arg PYTHON_VERSION="$PYTHON_VERSION" \
-        --build-arg ARROW_VERSION_RULE="<1" \
-        --build-arg NUMPY_VERSION_RULE="<1.20.0" \
-        +test/result /result
-
-    SAVE ARTIFACT /result AS LOCAL result
 
 test-python3.8-arrow1.x.x:
     ARG PYTHON_VERSION="3.8.12"
@@ -211,15 +202,6 @@ test-python3.8-arrow-nightly:
         +test/result /result
 
     SAVE ARTIFACT /result AS LOCAL result/$EARTHLY_TARGET_NAME
-
-test-python3.9-arrow0.x.x:
-    ARG PYTHON_VERSION="3.9.10"
-    COPY --build-arg PYTHON_VERSION="$PYTHON_VERSION" \
-        --build-arg ARROW_VERSION_RULE="<1" \
-        --build-arg NUMPY_VERSION_RULE="<1.20.0" \
-        +test/result /result
-
-    SAVE ARTIFACT /result AS LOCAL result
 
 test-python3.9-arrow1.x.x:
     ARG PYTHON_VERSION="3.9.10"
@@ -368,7 +350,6 @@ test-python3.10-arrow-nightly:
     SAVE ARTIFACT /result AS LOCAL result/$EARTHLY_TARGET_NAME
     
 test-python3.8-all:
-    BUILD test-python3.8-arrow0.x.x
     BUILD test-python3.8-arrow1.x.x
     BUILD test-python3.8-arrow2.x.x
     BUILD test-python3.8-arrow3.x.x
@@ -379,7 +360,6 @@ test-python3.8-all:
     BUILD test-python3.8-arrow-nightly
 
 test-python3.9-all:
-    BUILD test-python3.9-arrow0.x.x
     BUILD test-python3.9-arrow1.x.x
     BUILD test-python3.9-arrow2.x.x
     BUILD test-python3.9-arrow3.x.x

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ other popular ODBC modules do.
 
 Turbodbc is free to use ([MIT license](https://github.com/blue-yonder/turbodbc/blob/master/LICENSE)),
 open source ([GitHub](https://github.com/blue-yonder/turbodbc)),
-works with Python 3.7+, and is available for Linux, macOS, and Windows.
+works with Python 3.8+, and is available for Linux, macOS, and Windows.
 
 Turbodbc is routinely tested with [MySQL](https://www.mysql.com),
 [PostgreSQL](https://www.postgresql.org), [EXASOL](http://www.exasol.com),

--- a/cpp/turbodbc_arrow/Test/tests/arrow_result_set_test.cpp
+++ b/cpp/turbodbc_arrow/Test/tests/arrow_result_set_test.cpp
@@ -6,14 +6,8 @@
 #undef BOOL
 #undef timezone
 #include <arrow/api.h>
-// ARROW_VERSION is defined from 0.13.0 on
-#ifdef ARROW_VERSION
-  #include <arrow/testing/gtest_util.h>
-  #include <arrow/testing/util.h>
-#else
-  #include <arrow/test-util.h>
-  #define ARROW_EXPECT_OK EXPECT_OK
-#endif
+#include <arrow/testing/gtest_util.h>
+#include <arrow/testing/util.h>
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 #include <sql.h>
@@ -106,11 +100,7 @@ class ArrowResultSetTest : public ::testing::Test {
         std::shared_ptr<arrow::Array> MakePrimitive(int64_t length, int64_t null_count = 0) {
             std::shared_ptr<arrow::ResizableBuffer> data;
             const int64_t data_nbytes = length * sizeof(typename ArrayType::value_type);
-#if ARROW_VERSION_MAJOR > 0 || ARROW_VERSION_MINOR >= 17
             data = *AllocateResizableBuffer(data_nbytes, pool);
-#else
-            ARROW_EXPECT_OK(AllocateResizableBuffer(pool, data_nbytes, &data));
-#endif
 
             // Fill with random data
             random_bytes(data_nbytes, 0 /*random_seed*/, data->mutable_data());
@@ -121,11 +111,7 @@ class ArrowResultSetTest : public ::testing::Test {
 #else
             const int64_t null_nbytes = arrow::BitUtil::BytesForBits(length);
 #endif
-#if ARROW_VERSION_MAJOR > 0 || ARROW_VERSION_MINOR >= 17
             null_bitmap = *AllocateResizableBuffer(null_nbytes, pool);
-#else
-            ARROW_EXPECT_OK(AllocateResizableBuffer(pool, null_nbytes, &null_bitmap));
-#endif
             memset(null_bitmap->mutable_data(), 255, null_nbytes);
             for (int64_t i = 0; i < null_count; i++) {
 #if ARROW_VERSION_MAJOR >= 7

--- a/docs/pages/contributing.rst
+++ b/docs/pages/contributing.rst
@@ -173,8 +173,8 @@ do the following:
 
     ::
 
-        wget -q https://github.com/pybind/pybind11/archive/v2.8.1.tar.gz
-        tar xvf v2.8.1.tar.gz
+        wget -q https://github.com/pybind/pybind11/archive/v2.9.1.tar.gz
+        tar xvf v2.9.1.tar.gz
 
 #.  Create a build directory somewhere and ``cd`` into it.
 

--- a/docs/pages/introduction.rst
+++ b/docs/pages/introduction.rst
@@ -20,8 +20,8 @@ Features
 *   Supported data types for both result sets and parameters:
     ``int``, ``float``, ``str``, ``bool``, ``datetime.date``, ``datetime.datetime``
 *   Also provides a high-level C++11 database driver under the hood
-*   Tested with Python 3.7, 3.8 and 3.9
-*   Tested on 64 bit versions of Linux, OSX, and Windows (Python 3.7+).
+*   Tested with Python 3.8, 3.9 and 3.10
+*   Tested on 64 bit versions of Linux, OSX, and Windows (Python 3.8+).
 
 
 Why should I use turbodbc instead of other ODBC modules?

--- a/google_test/build_google_test.sh
+++ b/google_test/build_google_test.sh
@@ -2,10 +2,10 @@
 FLAGS=$1
 
 echo "Cloning latest google test repository"
-wget https://github.com/google/googletest/archive/release-1.8.0.tar.gz -O googletest-1.8.0.tar.gz
-tar xf googletest-1.8.0.tar.gz
+wget https://github.com/google/googletest/archive/release-1.11.0.tar.gz -O googletest-1.11.0.tar.gz
+tar xf googletest-1.11.0.tar.gz
 
 mkdir build
 cd build
-cmake ../googletest-release-1.8.0 -DCMAKE_INSTALL_PREFIX=../dist -DCMAKE_CXX_FLAGS="${FLAGS}"
+cmake ../googletest-release-1.11.0 -DCMAKE_INSTALL_PREFIX=../dist -DCMAKE_CXX_FLAGS="${FLAGS}"
 cmake --build . --target install

--- a/python/turbodbc/cursor.py
+++ b/python/turbodbc/cursor.py
@@ -185,9 +185,6 @@ class Cursor(object):
             import pyarrow as pa
 
             def _num_chunks(c):
-                if not isinstance(c, pa.ChunkedArray):
-                    # pyarrow < 0.15
-                    c = c.data
                 return c.num_chunks
 
             if isinstance(columns, pa.Table):

--- a/setup.py
+++ b/setup.py
@@ -205,7 +205,7 @@ with open(os.path.join(here, 'README.md')) as f:
 
 
 setup(name = 'turbodbc',
-      version = '4.3.1',
+      version = '4.4.0',
       description = 'turbodbc is a Python DB API 2.0 compatible ODBC driver',
       long_description=long_description,
       long_description_content_type='text/markdown',
@@ -215,8 +215,8 @@ setup(name = 'turbodbc',
       author_email = 'michael.koenig@blue-yonder.com',
       packages = ['turbodbc'],
       extras_require={
-          'arrow': ['pyarrow>=0.15,<7.1.0'],
-          'numpy': 'numpy>=1.17.0'
+          'arrow': ['pyarrow>=1.0,<7.1.0'],
+          'numpy': 'numpy>=1.19.0'
       },
       classifiers = ['Development Status :: 5 - Production/Stable',
                      'Intended Audience :: Developers',
@@ -225,7 +225,6 @@ setup(name = 'turbodbc',
                      'Operating System :: MacOS :: MacOS X',
                      'Operating System :: Microsoft :: Windows',
                      'Programming Language :: C++',
-                     'Programming Language :: Python :: 3.7',
                      'Programming Language :: Python :: 3.8',
                      'Programming Language :: Python :: 3.9',
                      'Programming Language :: Python :: 3.10',

--- a/setup.py
+++ b/setup.py
@@ -214,7 +214,7 @@ setup(name = 'turbodbc',
       author='Michael Koenig',
       author_email = 'michael.koenig@blue-yonder.com',
       packages = ['turbodbc'],
-      python_requires'>=3.8',
+      python_requires='>=3.8',
       extras_require={
           'arrow': ['pyarrow>=1.0,<7.1.0'],
           'numpy': 'numpy>=1.19.0'

--- a/setup.py
+++ b/setup.py
@@ -214,6 +214,7 @@ setup(name = 'turbodbc',
       author='Michael Koenig',
       author_email = 'michael.koenig@blue-yonder.com',
       packages = ['turbodbc'],
+      python_requires'>=3.8',
       extras_require={
           'arrow': ['pyarrow>=1.0,<7.1.0'],
           'numpy': 'numpy>=1.19.0'


### PR DESCRIPTION
This simplifies the build code and build time a little bit. The removal of numpy 1.17 and 1.18 is following the NEP 29 guide. Dropping Arrow 0.15 and 0.17 matches the Pandas (1.4) decision and allows to remove some macros too.