### PR TITLE
Improve support for multithreading

### DIFF
--- a/cpp/turbodbc_python/Library/src/python_bindings/connect.cpp
+++ b/cpp/turbodbc_python/Library/src/python_bindings/connect.cpp
@@ -6,7 +6,7 @@ namespace turbodbc { namespace bindings {
 
 void for_connect(pybind11::module & module)
 {
-    module.def("connect", turbodbc::connect);
+    module.def("connect", turbodbc::connect, pybind11::call_guard<pybind11::gil_scoped_release>());
 }
 
 } }

--- a/cpp/turbodbc_python/Library/src/python_bindings/connection.cpp
+++ b/cpp/turbodbc_python/Library/src/python_bindings/connection.cpp
@@ -7,10 +7,10 @@ namespace turbodbc { namespace bindings {
 
 void for_connection(pybind11::module &module) {
     pybind11::class_<turbodbc::connection>(module, "Connection")
-        .def("commit", &turbodbc::connection::commit)
-        .def("rollback", &turbodbc::connection::rollback)
-        .def("cursor", &turbodbc::connection::make_cursor)
-        .def("set_autocommit", &turbodbc::connection::set_autocommit)
+        .def("commit", &turbodbc::connection::commit, pybind11::call_guard<pybind11::gil_scoped_release>())
+        .def("rollback", &turbodbc::connection::rollback, pybind11::call_guard<pybind11::gil_scoped_release>())
+        .def("cursor", &turbodbc::connection::make_cursor, pybind11::call_guard<pybind11::gil_scoped_release>())
+        .def("set_autocommit", &turbodbc::connection::set_autocommit, pybind11::call_guard<pybind11::gil_scoped_release>())
         .def("autocommit_enabled", &turbodbc::connection::autocommit_enabled)
         ;
 

--- a/cpp/turbodbc_python/Library/src/python_bindings/cursor.cpp
+++ b/cpp/turbodbc_python/Library/src/python_bindings/cursor.cpp
@@ -8,12 +8,9 @@ namespace turbodbc { namespace bindings {
 void for_cursor(pybind11::module & module)
 {
     pybind11::class_<turbodbc::cursor>(module, "Cursor")
-            .def("prepare", &turbodbc::cursor::prepare)
-            .def("execute", [](turbodbc::cursor& cursor) {
-                pybind11::gil_scoped_release release;
-                cursor.execute();
-            })
-            .def("_reset",  &turbodbc::cursor::reset)
+            .def("prepare", &turbodbc::cursor::prepare, pybind11::call_guard<pybind11::gil_scoped_release>())
+            .def("execute", &turbodbc::cursor::execute, pybind11::call_guard<pybind11::gil_scoped_release>())
+            .def("_reset",  &turbodbc::cursor::reset, pybind11::call_guard<pybind11::gil_scoped_release>())
             .def("get_row_count", &turbodbc::cursor::get_row_count)
             .def("get_result_set", &turbodbc::cursor::get_result_set)
             .def("more_results", &turbodbc::cursor::more_results)


### PR DESCRIPTION
Currently we are quite conservative with releasing the GIL - this lowers performance in multithreaded use and also creates possibility for deadlocks when used with connection poolers (i.e. SQL Governor / pgpool).

This PR adds releasing the GIL in various key bits of the code which perform blocking calls (using pybind11::call_guard<pybind11::gil_scoped_release>).

I've tested this in a multithreaded app and performance improvement was ~30% or so, though of course YMMV.

I think these changes should be safe - we have dbapi threadsafety set to 1, so clients expect that connections are not safe to be shared between threads.

Please let me know what you think!