### PR TITLE
Add pyproject.toml to build artifact to meet pep517

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,11 +3,15 @@ Version history / changelog
 
 From version 2.0.0, turbodbc adapts semantic versioning.
 
+Version 4.9.0
+-------------
+
+* Fix pip wheel missing pyproject.toml - support pep517
+
 Version 4.8.0
 -------------
 
 * Support ``pyarrow=14``
-
 
 Version 4.7.0
 -------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,6 @@ if(BUILD_TESTING)
 endif()
 
 install(
-	FILES setup.py setup.cfg MANIFEST.in Makefile LICENSE README.md CHANGELOG.rst
+	FILES setup.py setup.cfg MANIFEST.in Makefile LICENSE README.md CHANGELOG.rst pyproject.toml
 	DESTINATION .
 )

--- a/setup.py
+++ b/setup.py
@@ -255,7 +255,7 @@ with open(os.path.join(here, "README.md")) as f:
 
 setup(
     name="turbodbc",
-    version="4.8.0",
+    version="4.9.0",
     description="turbodbc is a Python DB API 2.0 compatible ODBC driver",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
pyproject.toml was missing in the tar.gz build artifact.  This caused the command `pip wheel --use-pep517 "turbodbc==4.8.0"` to fail.

I verified the problem with the below commands and then tested the change the same way.
```
cmake -DBOOST_ROOT=$CONDA_PREFIX -DBUILD_COVERAGE=ON -DCMAKE_INSTALL_PREFIX=./dist -DPYTHON_EXECUTABLE=$(which python) -GNinja .. && ninja && cmake --build . --target install && cd dist && python setup.py sdist

pip wheel --use-pep517 "dist/turbodbc-4.9.0.tar.gz"
```