### PR TITLE
Update pyproject.toml to include pyarrow < 16

### DIFF
--- a/earthly/odbc/odbcinst.ini
+++ b/earthly/odbc/odbcinst.ini
@@ -10,4 +10,4 @@ Threading   = 2
 
 [ODBC Driver 17 for SQL Server]
 Description = Microsoft ODBC Driver 17 for SQL Server
-Driver      = /opt/microsoft/msodbcsql17/lib64/libmsodbcsql-17.10.so.5.1
+Driver      = /opt/microsoft/msodbcsql17/lib64/libmsodbcsql-17.10.so.6.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ['setuptools', 'wheel', 'pyarrow>=7', 'pybind11', 'oldest-supported-numpy']
+requires = ['setuptools', 'wheel', 'pyarrow>=7,<16', 'pybind11', 'oldest-supported-numpy']
 
 [tool.black]
 exclude = '''


### PR DESCRIPTION
setup.py requires pyarrow<16, so should be reflected here as well