### PR TITLE
Fix macOS Installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -93,6 +93,7 @@ if sys.platform == "darwin":
 
     config_vars = distutils.sysconfig.get_config_vars()
     config_vars["LDSHARED"] = config_vars["LDSHARED"].replace("-bundle", "")  # type: ignore
+    config_vars["LDCXXSHARED"] = config_vars["LDCXXSHARED"].replace("-bundle", "")  # type: ignore
     python_module_link_args.append("-bundle")
     builder = setuptools.command.build_ext.build_ext(Distribution())
     full_name = builder.get_ext_filename("libturbodbc")


### PR DESCRIPTION
Apply the same `"-bundle"` linker flag truncation across both `"LDSHARED"` and `"LDCXXSHARED"`.

I found this to be required to install the `turbodbc-4.14.0.tar.gz` archive from https://pypi.org/project/turbodbc/#files.

Specifically, I followed these steps (in the `turbodbc` git repo root):
```sh
brew install unixodbc boost simdutf
export LDFLAGS
export CPPFLAGS
for brewlib in "simdutf/5.4.15" "boost/1.86.0"; do
  LDFLAGS+="-L/opt/homebrew/Cellar/${brewlib}/lib "
  CPPFLAGS+="-I/opt/homebrew/Cellar/${brewlib}/include "
done
export UNIXODBC_LIBRARY_DIR=/opt/homebrew/Cellar/unixodbc/2.3.12/lib
export UNIXODBC_INCLUDE_DIR=/opt/homebrew/Cellar/unixodbc/2.3.12/include
pip wheel .
 ```

System info (python installed using `pyenv`):
```
❯ which clang++
/usr/bin/clang++
❯ clang++ --version
Apple clang version 15.0.0 (clang-1500.3.9.4)
Target: arm64-apple-darwin23.6.0
Thread model: posix
InstalledDir: /Library/Developer/CommandLineTools/usr/bin
❯ uname -a
Darwin AlexandersMBP2.localdomain 23.6.0 Darwin Kernel Version 23.6.0: Mon Jul 29 21:16:46 PDT 2024; root:xnu-10063.141.2~1/RELEASE_ARM64_T8112 arm64
❯ python -V
Python 3.12.5
```